### PR TITLE
fix: 新規パネル表示時の表示位置を調整

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -54,6 +54,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
   @ViewChild('modalLayer', { read: ViewContainerRef }) modalLayerViewContainerRef: ViewContainerRef;
   private lazyUpdateTimer: NodeJS.Timer = null;
+  private openPanelCount: number = 0;
 
   constructor(
     private modalService: ModalService,
@@ -177,6 +178,10 @@ export class AppComponent implements AfterViewInit, OnDestroy {
         break;
     }
     if (component) {
+      option.top = (this.openPanelCount % 10 + 1) * 20;
+      option.left = 100 + (this.openPanelCount % 20 + 1) * 5;
+      this.openPanelCount = this.openPanelCount + 1;
+      console.log('openPanelCount:', this.openPanelCount);
       this.panelService.open(component, option);
     }
   }


### PR DESCRIPTION
# 概要

メニュークリック時に作成される新規パネルの表示位置を、徐々にずらしていくようにするものです。

テスト環境： http://udo.opal.ne.jp/

# 背景

現状、常に同じ位置に表示されるため、描画が速い環境でパネルが開いたことに気づかず、何度かクリックしてしまい多重に開くことがあったことから、ウィンドウシステムによくある動作として追加しました。

# 備考

Typescriptにまだ不慣れなため、変数の持ち方など不適切な点があればご指摘ください。
