### PR TITLE
feat: テーブルグリッドの種類およびグリッド常時表示切替を追加

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -158,7 +158,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
         break;
       case 'GameTableSettingComponent':
         component = GameTableSettingComponent;
-        option = { width: 500, height: 300, left: 100 };
+        option = { width: 500, height: 350, left: 100 };
         break;
       case 'FileStorageComponent':
         component = FileStorageComponent;

--- a/src/app/class/game-table.ts
+++ b/src/app/class/game-table.ts
@@ -13,6 +13,8 @@ export interface GameTableDataContainer {
   height: number;
   gridSize: number;
   imageIdentifier: string;
+  gridType: number;
+  gridShow: boolean;
 }
 
 @SyncObject('game-table')
@@ -23,6 +25,8 @@ export class GameTable extends GameObject implements InnerXml {
   @SyncVar() gridSize: number = 50;
   @SyncVar() imageIdentifier: string = 'imageIdentifier';
   @SyncVar() selected: boolean = false;
+  @SyncVar() gridType: number = 0; // 0=square 1=hex(縦揃え) 2=hex(横揃え)
+  @SyncVar() gridShow: boolean = false; // true=常時グリッド表示
 
   innerXml(): string {
     let xml = '';

--- a/src/app/class/table-selecter.ts
+++ b/src/app/class/table-selecter.ts
@@ -27,6 +27,8 @@ export class TableSelecter extends GameObject {
           height: gameTable.height,
           imageIdentifier: gameTable.imageIdentifier,
           gridSize: gameTable.gridSize,
+          gridType: gameTable.gridType,
+          gridShow: gameTable.gridShow,
         }
         EventSystem.call('UPDATE_GAME_TABLE', data);
         gameTable.selected = true;

--- a/src/app/component/game-table-setting/game-table-setting.component.html
+++ b/src/app/component/game-table-setting/game-table-setting.component.html
@@ -19,7 +19,15 @@
       <input [(ngModel)]="tableHeight" type="number" min="{{minSize}}" max="{{maxSize}}" style="width: 5em;">
     </div>
     <div>
-      <button (click)="updateGameTableSettings()">変更</button>
+      グリッド:<select (change)="changeGridType($event.target.value)" [ngModel]="tableGridType" name="tableGridType">
+        <option value="0">スクエア</option>
+        <option value="1">ヘクス（縦揃え）</option>
+        <option value="2">ヘクス（横揃え）</option>
+      </select>
+      常時:<input type="checkbox" (change)="changeGridShow($event.target.checked)" [ngModel]="tableGridShow" name="tableGridType" />
+    </div>
+    <hr/>
+    <div>
       <button (click)="save()">現在の状態を保存</button>
     </div>
   </div>

--- a/src/app/component/game-table-setting/game-table-setting.component.ts
+++ b/src/app/component/game-table-setting/game-table-setting.component.ts
@@ -26,6 +26,8 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
   _tableName: string = '';
   _tableWidth: number = 20;
   _tableHeight: number = 20;
+  _tableGridType: number = 0;
+  _tableGridShow: boolean = false;
   minSize: number = 1;
   maxSize: number = 100;
   tableBackgroundImage: ImageFile = ImageFile.createEmpty('null');
@@ -47,6 +49,10 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
     this._tableHeight = tableHeight;
     this.updateGameTableSettings();
   }
+
+  get tableGridShow(): boolean { return this._tableGridShow };
+
+  get tableGridType(): number { return this._tableGridType };
 
   get viewTable(): GameTable {
     return ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;
@@ -94,6 +100,8 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
     this._tableName = gameTable.name;
     this._tableHeight = gameTable.height;
     this._tableWidth = gameTable.width;
+    this._tableGridType = gameTable.gridType;
+    this._tableGridShow = gameTable.gridShow;
   }
 
   updateGameTableSettings() {
@@ -108,6 +116,8 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
     gameTable.height = this.tableHeight;
     gameTable.imageIdentifier = this.tableBackgroundImage.identifier;
     gameTable.gridSize = 50;
+    gameTable.gridType = this.tableGridType;
+    gameTable.gridShow = this.tableGridShow;
     gameTable.update();
   }
 
@@ -154,6 +164,18 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
       if (file) this.tableBackgroundImage = file;
       this.viewTable.imageIdentifier = value;
     });
+  }
+
+  changeGridType(target: string) {
+    console.log('changeGridType',target);
+    this._tableGridType = Number(target);
+    this.updateGameTableSettings();
+  }
+
+  changeGridShow(target: boolean) {
+    console.log('changeGridShow',target);
+    this._tableGridShow = target;
+    this.updateGameTableSettings();
   }
 }
 


### PR DESCRIPTION
# 概要

テーブルのグリッドにヘクス（正方形の交互配置による擬似ヘクス）と座標描画、およびグリッドの常時表示の機能を追加するものです。
テーブル設定画面、およびTableSelecterクラスのデータ構造に変更が生じます。（gridShow、gridTypeを追加）

テスト環境： http://udo.opal.ne.jp/


# 背景

ヘクスマップを利用するシステムへの対応と、グリッドを常時必要とするシーンへの対応として常時表示・座標表示の機能が必要と考え追加しました。


# 備考

- 座標の文字の解像度が低いという懸念があります。gridSizeを100px程度にすると文字の視認性は良くなりますが、影響範囲が大きいと見たため今回は見送りました。
- 座標の表示on/offは「グリッド常時表示時に座標が不要なケース」「グリッド無しで座標のみ必要なケース」が浮かばなかったため、常時表示のon/offのみで充分であろうとあえて設けていません。
- グリッドの色変更の機能も検討しましたが、グリッド色のデータの持ち方(string or number)で迷ったため今回は見送りました。