### PR TITLE
fix: シークレットダイスを実装

### DIFF
--- a/src/app/class/chat-message.ts
+++ b/src/app/class/chat-message.ts
@@ -52,6 +52,8 @@ export class ChatMessage extends ObjectNode implements ChatMessageContext, Inner
   get isDirect(): boolean { return 0 < this.sendTo.length ? true : false; }
   get isMine(): boolean { return (-1 < this.sendTo.indexOf(Network.peerContext.id)) || this.from === Network.peerContext.id ? true : false; }
   get isDisplayable(): boolean { return this.isDirect ? this.isMine : true; }
+  get isSystem(): boolean { return this.tag === 'system' ? true : false; }
+  get isDicebot(): boolean { return this.isSystem && this.from === 'System-BCDice' ? true : false; }
 
   innerXml(): string {
     return this.isDirect ? '' : super.innerXml();

--- a/src/app/class/dice-bot.ts
+++ b/src/app/class/dice-bot.ts
@@ -308,12 +308,28 @@ export class DiceBot extends GameObject {
             identifier: '',
             tabIdentifier: chatMessage.tabIdentifier,
             from: 'System-BCDice',
+            timestamp: chatMessage.timestamp + 2,
+            imageIdentifier: '',
+            tag: 'system',
+            name: isSecret ? '<BCDice：シークレットダイス>' : '<BCDice：' + chatMessage.name + '>',
+            text: result
+          };
+
+          let diceBotMessageSecretBroadcast: ChatMessageContext = {
+            identifier: '',
+            tabIdentifier: chatMessage.tabIdentifier,
+            from: 'System-BCDice',
             timestamp: chatMessage.timestamp + 1,
             imageIdentifier: '',
             tag: 'system',
-            name: isSecret ? '<BCDice：シークレットダイス（未実装）>' : '<BCDice>',
-            text: result
+            name: '<BCDice：' + chatMessage.name + '>',
+            text: '(シークレットダイス)'
           };
+
+          if( isSecret ){
+            EventSystem.call('BROADCAST_MESSAGE', diceBotMessageSecretBroadcast);
+            chatMessage.to = chatMessage.from;
+          }
 
           if (chatMessage.to != null && 0 < chatMessage.to.length) {
             diceBotMessage.to = chatMessage.to;

--- a/src/app/component/chat-message/chat-message.component.css
+++ b/src/app/component/chat-message/chat-message.component.css
@@ -49,3 +49,11 @@
 .message .tip {
   font-size: 8px;
 }
+
+.dicebot-message .msg-text {
+  color:#22F;
+}
+
+.direct-message.dicebot-message .msg-text {
+  color:#CCF;
+}

--- a/src/app/component/chat-message/chat-message.component.html
+++ b/src/app/component/chat-message/chat-message.component.html
@@ -1,15 +1,15 @@
 <div class="container">
-  <div class="message" [ngClass]="{'direct-message': chatMessage.isDirect}" [@flyInOut]="'in'">
+  <div class="message" [ngClass]="{'direct-message': chatMessage.isDirect, 'system-message':chatMessage.isSystem, 'dicebot-message': chatMessage.isDicebot}" [@flyInOut]="'in'">
     <div class="image">
       <img *ngIf="0 < imageFile?.url?.length" [src]="imageFile?.url | safe: 'resourceUrl'" />
     </div>
     <div class="body">
       <div class="title">
-        <span style="font-weight: bold;">{{chatMessage.name}}</span>
-        <span class='tip'>　From: {{chatMessage.from}}</span>
-        <span class='tip'>　{{chatMessage.timestamp | date:'y/M/d H:mm'}}</span>
+        <span class="msg-name" style="font-weight: bold;">{{chatMessage.name}}</span>
+        <span class='tip msg-from'>　From: {{chatMessage.from}}</span>
+        <span class='tip msg-timestamp'>　{{chatMessage.timestamp | date:'y/M/d H:mm'}}</span>
       </div>
-      <div class="text"><span>{{chatMessage.text}}</span></div>
+      <div class="text msg-text"><span>{{chatMessage.text}}</span></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
# 概要

未実装とされていたシークレットダイスの機能を、自身への秘話という形で実装するものです。シークレットダイスを行った旨のみ接続Peer先に送信されます。

テスト環境： http://udo.opal.ne.jp/


# 備考

- 複数人のBCDiceの結果が並んだ際に誰のものかわかり辛かったため、プレイヤー名を表示するようにしています。
- BCDiceの結果と通常のチャットとを区別するため、chat-messageにメッセージ種別の判定と、class指定を付加しています。