### PR TITLE
キャラクターを反転させる機能を追加

### DIFF
--- a/src/app/class/game-character.ts
+++ b/src/app/class/game-character.ts
@@ -8,7 +8,8 @@ import { ChatPalette } from './chat-palette';
 export class GameCharacter extends TabletopObject {
   get name(): string { return this.getCommonValue('name', ''); }
   get size(): number { return this.getCommonValue('size', 1); }
-
+  get flip(): boolean { return Boolean(this.getCommonValue('flip', 0)); }
+  
   get chatPalette(): ChatPalette {
     for (let child of this.children) {
       if (child instanceof ChatPalette) return child;
@@ -22,23 +23,24 @@ export class GameCharacter extends TabletopObject {
     this.update();
   }
 
-  static createGameCharacter(name: string, size: number, imageIdentifier: string): GameCharacter {
+  static createGameCharacter(name: string, size: number, flip:boolean, imageIdentifier: string): GameCharacter {
     let gameCharacter: GameCharacter = new GameCharacter();
     gameCharacter.createDataElements();
     //gameCharacter.syncData.imageIdentifier = imageIdentifier;
     //gameCharacter.syncData.name = name;
     //gameCharacter.syncData.size = size;
     gameCharacter.initialize();
-    gameCharacter.createTestGameDataElement(name, size, imageIdentifier);
+    gameCharacter.createTestGameDataElement(name, size, flip, imageIdentifier);
 
     return gameCharacter;
   }
 
-  createTestGameDataElement(name: string, size: number, imageIdentifier: string) {
+  createTestGameDataElement(name: string, size: number, flip:boolean, imageIdentifier: string) {
     this.createDataElements();
 
     let nameElement: DataElement = DataElement.create('name', name, {}, 'name_' + this.identifier);
     let sizeElement: DataElement = DataElement.create('size', size, {}, 'size_' + this.identifier);
+    let flipElement: DataElement = DataElement.create('flip', Number(flip), { 'type': 'bool' }, 'flip_' + this.identifier);
 
     if (this.imageDataElement.getFirstElementByName('imageIdentifier')) {
       this.imageDataElement.getFirstElementByName('imageIdentifier').value = imageIdentifier;
@@ -51,6 +53,7 @@ export class GameCharacter extends TabletopObject {
 
     this.commonDataElement.appendChild(nameElement);
     this.commonDataElement.appendChild(sizeElement);
+    this.commonDataElement.appendChild(flipElement);
 
     this.detailDataElement.appendChild(resourceElement);
     resourceElement.appendChild(hpElement);
@@ -107,6 +110,7 @@ export class GameCharacter extends TabletopObject {
 export interface GameCharacterContainer {
   name: string;
   size: number;
+  flip: boolean;
   imageIdentifier: string;
   dataElementIdentifier: string;
   location: GameObjectLocationContainer;

--- a/src/app/component/game-character-generator/game-character-generator.component.html
+++ b/src/app/component/game-character-generator/game-character-generator.component.html
@@ -1,6 +1,8 @@
 <button (click)="openModal()">画像を選ぶ</button>
 <div>
-  <img height="120" [src]="tableBackgroundImage.url | safe: 'resourceUrl'">
+  <img *ngIf="!flip" height="120" [src]="tableBackgroundImage.url | safe: 'resourceUrl'">
+  <img *ngIf="flip" style="transform:scaleX(-1);" height="120" [src]="tableBackgroundImage.url | safe: 'resourceUrl'">
+  <input type="checkbox" [(ngModel)]="flip" />反転
 </div>
 <input [(ngModel)]="name" placeholder="Name" name="name" />
 <div>

--- a/src/app/component/game-character-generator/game-character-generator.component.ts
+++ b/src/app/component/game-character-generator/game-character-generator.component.ts
@@ -25,6 +25,7 @@ export class GameCharacterGeneratorComponent implements OnInit, OnDestroy, After
 
   name: string = "ゲームキャラクター";
   size: number = 1;
+  flip: boolean = false;
   xml: string = '';
 
   minSize: number = 1;
@@ -60,7 +61,7 @@ export class GameCharacterGeneratorComponent implements OnInit, OnDestroy, After
   }
 
   createGameCharacter() {
-    GameCharacter.createGameCharacter(this.name, this.size, this.tableBackgroundImage.identifier);
+    GameCharacter.createGameCharacter(this.name, this.size, this.flip, this.tableBackgroundImage.identifier);
   }
   createGameTableMask() {
     let viewTable = ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;

--- a/src/app/component/game-character-sheet/game-character-sheet.component.css
+++ b/src/app/component/game-character-sheet/game-character-sheet.component.css
@@ -5,9 +5,14 @@
   */
   width: 250px;
   height: 250px;
+  z-index: -1;
 }
 .main-image {
   width: 250px;
+}
+
+.flip {
+  transform: scaleX(-1);
 }
 
 .table {

--- a/src/app/component/game-character-sheet/game-character-sheet.component.html
+++ b/src/app/component/game-character-sheet/game-character-sheet.component.html
@@ -21,8 +21,8 @@
 </ng-container>
 <div *ngIf="tabletopObject" class="flex-container">
   <div *ngIf="0 < tabletopObject.imageFile?.url.length" class="box main-image-box">
-    <img class="main-image" [src]="tabletopObject.imageFile.url | safe: 'resourceUrl'" [alt]="tabletopObject.imageFile.name"
-    />
+    <img *ngIf="!tabletopObject.flip" class="main-image" [src]="tabletopObject.imageFile.url | safe: 'resourceUrl'" [alt]="tabletopObject.imageFile.name" />
+    <img *ngIf="tabletopObject.flip" class="main-image flip" [src]="tabletopObject.imageFile.url | safe: 'resourceUrl'" [alt]="tabletopObject.imageFile.name" />
   </div>
   <ng-container *ngIf="tabletopObject.commonDataElement">
     <div class="flex-item">

--- a/src/app/component/game-character/game-character.component.css
+++ b/src/app/component/game-character/game-character.component.css
@@ -92,6 +92,10 @@
   vertical-align: bottom;
 }
 
+.flip {
+  transform: scaleX(-1);
+}
+
 .name-tag {
   box-sizing: border-box;
   font-size: 15px;

--- a/src/app/component/game-character/game-character.component.html
+++ b/src/app/component/game-character/game-character.component.html
@@ -9,7 +9,8 @@
         <div *ngIf="0 < name.length" class="name-tag is-nowrap is-black-background" [ngStyle]="{'transform': 'translateX(-50%) translateX(' + size * gridSize / 2 +'px)'}">
           <span>{{name}}</span>
         </div>
-        <img class="image" *ngIf="0 < imageFile.url.length" [src]="imageFile.url | safe: 'resourceUrl'">
+        <img class="image" *ngIf="0 < imageFile.url.length && !flip" [src]="imageFile.url | safe: 'resourceUrl'">
+        <img class="image flip" *ngIf="0 < imageFile.url.length && flip" [src]="imageFile.url | safe: 'resourceUrl'">
       </div>
     </div>
   </div>

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -39,6 +39,7 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
 
   get name(): string { return this.gameCharacter.name; }
   get size(): number { return this.adjustMinBounds(this.gameCharacter.size); }
+  get flip(): boolean { return this.gameCharacter.flip; }
   get imageFile(): ImageFile { return this.gameCharacter.imageFile; }
 
   gridSize: number = 50;

--- a/src/app/component/game-data-element/game-data-element.component.html
+++ b/src/app/component/game-data-element/game-data-element.component.html
@@ -36,6 +36,9 @@
         <ng-container *ngSwitchCase="'note'">
           <textarea style="width:100%; height:5em; min-width:50px; resize: none;" [(ngModel)]="gameDataElement.value" placeholder="Note"></textarea>
         </ng-container>
+        <ng-container *ngSwitchCase="'bool'">
+          <input [(ngModel)]="gameDataElement.value" ng-true-value="1" ng-false-value="0" type="checkbox"/>
+        </ng-container>
         <ng-container *ngSwitchDefault>
           <!--<input style="width:100%;" (change)="gameDataElement.update()" [(ngModel)]="gameDataElement.value" placeholder="Value"/>-->
           <!-- size属性がないと小さくならない -->

--- a/src/app/component/game-object-inventory/game-object-inventory.component.css
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.css
@@ -46,3 +46,7 @@
 .input_selected {
   color: #CCC;
 }
+
+.flip {
+  transform: scaleX(-1);
+}

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -14,7 +14,8 @@
       <div *ngFor="let gameObject of getGameObjects(inventoryType)" (click)="selectGameObject(gameObject)" [ngClass]="{'box': true, 'selected': (selectedIdentifier === gameObject.identifier)}">
         <div style="display: inline-block;">
           <div style="min-width:50px; min-height:50px; display: inline-block; vertical-align:text-top;">
-            <img *ngIf="gameObject.imageFile" height="50" [src]="gameObject.imageFile.url | safe: 'resourceUrl'" />
+            <img *ngIf="gameObject.imageFile && !gameObject.flip" height="50" [src]="gameObject.imageFile.url | safe: 'resourceUrl'" />
+            <img class="flip" *ngIf="gameObject.imageFile && gameObject.flip" height="50" [src]="gameObject.imageFile.url | safe: 'resourceUrl'" />
           </div>
           <div style="display: inline-block; vertical-align:text-top;" [ngClass]="{'input_selected': (selectedIdentifier === gameObject.identifier)}">
             <div style="font-size: 0.8rem;">{{gameObject.name}}</div>

--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -386,7 +386,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
 
   createGameCharacter(potison: PointerCoordinate) {
     console.log('mouseCursor B', potison);
-    let gameObject = GameCharacter.createGameCharacter('新しいキャラクター', 1, '');
+    let gameObject = GameCharacter.createGameCharacter('新しいキャラクター', 1, false, '');
     let pointer = PointerDeviceService.convertToLocal(potison, this.gameObjects.nativeElement);
     gameObject.location.x = pointer.x - 25;
     gameObject.location.y = pointer.y - 25;
@@ -624,13 +624,13 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 9 * 50;
     testCharacter.initialize();
-    testCharacter.createTestGameDataElement('モンスターA', 1, testFile.identifier);
+    testCharacter.createTestGameDataElement('モンスターA', 1, false, testFile.identifier);
 
     testCharacter = new GameCharacter('testCharacter_2');
     testCharacter.location.x = 8 * 50;
     testCharacter.location.y = 8 * 50;
     testCharacter.initialize();
-    testCharacter.createTestGameDataElement('モンスターB', 1, testFile.identifier);
+    testCharacter.createTestGameDataElement('モンスターB', 1, false, testFile.identifier);
 
     testCharacter = new GameCharacter('testCharacter_3');
     fileContext = ImageFile.createEmpty('testCharacter_3_image').toContext();
@@ -639,7 +639,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
     testCharacter.location.x = 4 * 50;
     testCharacter.location.y = 2 * 50;
     testCharacter.initialize();
-    testCharacter.createTestGameDataElement('モンスターC', 3, testFile.identifier);
+    testCharacter.createTestGameDataElement('モンスターC', 3, false, testFile.identifier);
 
     testCharacter = new GameCharacter('testCharacter_4');
     fileContext = ImageFile.createEmpty('testCharacter_4_image').toContext();
@@ -648,7 +648,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
     testCharacter.location.x = 6 * 50;
     testCharacter.location.y = 11 * 50;
     testCharacter.initialize();
-    testCharacter.createTestGameDataElement('キャラクターA', 1, testFile.identifier);
+    testCharacter.createTestGameDataElement('キャラクターA', 1, false, testFile.identifier);
 
     testCharacter = new GameCharacter('testCharacter_5');
     fileContext = ImageFile.createEmpty('testCharacter_5_image').toContext();
@@ -657,7 +657,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
     testCharacter.location.x = 12 * 50;
     testCharacter.location.y = 12 * 50;
     testCharacter.initialize();
-    testCharacter.createTestGameDataElement('キャラクターB', 1, testFile.identifier);
+    testCharacter.createTestGameDataElement('キャラクターB', 1, false, testFile.identifier);
 
     testCharacter = new GameCharacter('testCharacter_6');
     fileContext = ImageFile.createEmpty('testCharacter_6_image').toContext();
@@ -666,6 +666,6 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
     testCharacter.initialize();
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 13 * 50;
-    testCharacter.createTestGameDataElement('キャラクターC', 1, testFile.identifier);
+    testCharacter.createTestGameDataElement('キャラクターC', 1, false, testFile.identifier);
   }
 }


### PR DESCRIPTION
お疲れ様です。前回に引き続き、今回も機能を提案させて頂きたく思います。
需要がありましたらご一考くださいませ。

■概要■
キャラクター画像を左右反転させる機能を追加しています。

■意図すること■
右向きの素材を左向きに使用するなど、キャラクター表現の幅を広げたいと考えました。

■変更点■
・GameCharacterクラスにflipプロパティを追加して、反転状態を保持します。
・反転状態は、キャラクターシート上、キャラクタージェネレータ上のチェックボックスで切り替えます。
・チェックボックスを表示するため、'bool'というGameDataElementのタイプを追加しています。
・テーブル上のキャラクター画像、キャラクターシート上の画像、インベントリ上の画像、キャラクタージェネレータ上の画像が左右反転します。
・キャラクターシート上で反転画像を表示すると、他のデータより前面に表示されるため、main-imageのz-indexを-1に設定しています。

■備考■
・&&が赤くハイライトされていますが、こちらの環境では動いているので困惑しています。
　GitHub上で他の箇所を見ると、やはり&&が赤くなっているので、気にしないでいいのかなと思いつつそのままにしています。
・前回も書きましたが、Git,Typescript,Angularなどに不慣れです。間違ったことなどあれば、ご指摘いただきたけるとありがたく存じます。

■相談■
この実装では、「反転するかどうか」の情報を、GameCharacterクラスで保持していますが、
背景やマップマスク、地形の画像なども左右反転させる必要がありますでしょうか。
必要がありましたら、ImageFileクラスに手を加えて、画像が必要なところでは全て左右反転ができるようにできればと考えています。

長くなりましたが、ご確認よろしくおねがいします。