### PR TITLE
feat: 山札のカードサイズを一括調整する機能

### DIFF
--- a/src/app/class/card-stack.ts
+++ b/src/app/class/card-stack.ts
@@ -101,6 +101,12 @@ export class CardStack extends TabletopObject {
     }
   }
 
+  fitEveryCardSizeToTopCard(): void {
+    for (const card of this.cards) {
+      card.size = this.topCard.size;
+    }
+  }
+
   putOnTop(card: Card): Card {
     if (!this.cardRoot) return;
     if (!this.topCard) return this.putOnBottom(card);

--- a/src/app/class/card.ts
+++ b/src/app/class/card.ts
@@ -23,6 +23,7 @@ export class Card extends TabletopObject {
 
   get name(): string { return this.getCommonValue('name', ''); }
   get size(): number { return this.getCommonValue('size', 2); }
+  set size(size: number) { this.setCommonValue('size', size); }
   get frontImage(): ImageFile { return this.getImageFile('front'); }
   get backImage(): ImageFile { return this.getImageFile('back'); }
 

--- a/src/app/component/card-stack/card-stack.component.ts
+++ b/src/app/component/card-stack/card-stack.component.ts
@@ -225,6 +225,7 @@ export class CardStackComponent implements OnInit {
         : { name: '枚数を表示する', action: () => { this.cardStack.isShowTotal = true; } }
       ),
       { name: 'カード一覧', action: () => { this.showStackList(this.cardStack); } },
+      { name: 'カードサイズを揃える', action: () => { this.cardStack.fitEveryCardSizeToTopCard(); } },
       { name: '山札を人数分に分割する', action: () => { this.splitStack(Network.peerIds.length); } },
       { name: '山札を崩す', action: () => { this.breakStack(); } },
       { name: '詳細を表示', action: () => { this.showDetail(this.cardStack); } },


### PR DESCRIPTION
# 概要
山札のカードの大きさを一括で同じ大きさに変更する機能です。
山札の一番上のカードに大きさを揃えます。

# 背景
現状では例えば、トランプのカードサイズを初期の2から3に変更する際に、すべてのカードを1枚ずつ大きさ変更するしか方法がなくて不便だったため、実装しました。
