### PR TITLE
接続中の他のPeerのニックネームを表示したい

### DIFF
--- a/src/app/component/peer-menu/peer-menu.component.html
+++ b/src/app/component/peer-menu/peer-menu.component.html
@@ -25,7 +25,7 @@
 <div *ngFor="let conn of networkService.peerContexts">
   <div>
     <span *ngIf="!conn.isOpen">[接続中]</span>
-    <span>他のPeer：{{conn.id}} [{{findPeerName(conn.id)}}]</span>
+    <span>他のPeer：{{conn.id}} [{{findPeerName(conn.fullstring)}}]</span>
   </div>
 </div>
 <div>

--- a/src/app/component/peer-menu/peer-menu.component.html
+++ b/src/app/component/peer-menu/peer-menu.component.html
@@ -25,7 +25,7 @@
 <div *ngFor="let conn of networkService.peerContexts">
   <div>
     <span *ngIf="!conn.isOpen">[接続中]</span>
-    <span>他のPeer：{{conn.id}}</span>
+    <span>他のPeer：{{conn.id}} [{{findPeerName(conn.id)}}]</span>
   </div>
 </div>
 <div>

--- a/src/app/component/peer-menu/peer-menu.component.ts
+++ b/src/app/component/peer-menu/peer-menu.component.ts
@@ -144,4 +144,9 @@ export class PeerMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   showLobby() {
     this.modalService.open(LobbyComponent, { width: 700, height: 400, left: 0, top: 400 });
   }
+
+  findPeerName(peerId: string) {
+    const peerCursor = PeerCursor.find(peerId);
+    return peerCursor ? peerCursor.name : '';
+  }
 }


### PR DESCRIPTION
# 概要
Peer情報パネルの「他のPeer」に表示されるPeerIdの横に、ニックネームも並べて表示する機能

# 目的
誰がPeer接続中なのかを目視でわかるようにしたい

# 理由
ネットワークの不調やパソコンの一時スリープなどにより、
一方の端末ではPeer接続が解除されているのに、
もう一方の端末では接続中と誤認してしまう状況が何度か発生した。

上記の状況の際、該当の端末とPeer接続が継続中なのか、
解除されているのかを判別できるようにしたかったため。
