### PR TITLE
チャットに改行を入力・表現可能に

### DIFF
--- a/src/app/component/chat-message/chat-message.component.css
+++ b/src/app/component/chat-message/chat-message.component.css
@@ -50,6 +50,10 @@
   font-size: 8px;
 }
 
+.msg-text {
+  white-space: pre-wrap;
+}
+
 .dicebot-message .msg-text {
   /*color:#22F;*/
 }

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -39,8 +39,8 @@
     </div>
     <div>
       <form #chatWindowForm="ngForm">
-        <textarea [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" class="chat-input" (keydown.enter)="sendChat()"></textarea>
-        <button type="submit" (click)="sendChat()">SEND</button>
+        <textarea [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" class="chat-input" (keydown.enter)="sendChat($event)"></textarea>
+        <button type="submit" (click)="sendChat($event)">SEND</button>
       </form>
     </div>
   </div>

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -39,7 +39,7 @@
     </div>
     <div>
       <form #chatWindowForm="ngForm">
-        <input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" class="chat-input">
+        <textarea [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" class="chat-input" (keydown.enter)="sendChat()"></textarea>
         <button type="submit" (click)="sendChat()">SEND</button>
       </form>
     </div>

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -216,7 +216,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
-  sendChat() {
+  sendChat(event: Event) {
+    event.preventDefault();
+
     if (!this.text.length) return;
 
     if (!this.sender.length) this.sender = this.network.peerId;


### PR DESCRIPTION
#概要
チャットメッセージ内の改行を表現するものです。またそれに加えて、チャットウィンドウからの入力にて改行を行えるように機能修正しています。
チャットウインドウからの入力にて、~~Ctrl+Enter~~ Shift+Enterで改行を入力できるようになります。

テスト環境： http://yoshis-islands.sakura.ne.jp/udondev/