### PR TITLE
チャットウィンドウにて、墓場や他人のインベントリ内のキャラクターを選択できないように

### DIFF
--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -54,7 +54,9 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   set gameType(gameType: string) { this.chatMessageService.gameType = gameType; }
   gameHelp: string = '';
 
-  gameCharacters: GameCharacter[] = [];
+  private _gameCharacters: GameCharacter[] = [];
+  get gameCharacters(): GameCharacter[] { return this._gameCharacters.filter(character => this.isAccessibleCharacter(character)); }
+  set gameCharacters(gameCharacters: GameCharacter[]) { this._gameCharacters = gameCharacters; }
   gameCharacter: GameCharacter = null;
 
   private _chatTabidentifier: string = '';
@@ -280,6 +282,23 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     textArea.style.height = '';
     if (textArea.scrollHeight >= textArea.offsetHeight) {
       textArea.style.height = textArea.scrollHeight + 'px';
+    }
+  }
+
+  private isAccessibleCharacter(gameCharacter: GameCharacter): boolean {
+    switch (gameCharacter.location.name) {
+      case 'table':
+      case this.myPeer.peerId:
+        return true;
+      case 'graveyard':
+        return false;
+      default:
+        for (const conn of Network.peerContexts) {
+          if (conn.isOpen && gameCharacter.location.name === conn.fullstring) {
+            return false;
+          }
+        }
+        return true;
     }
   }
 }

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -106,6 +106,10 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
       })
       .on('UPDATE_GAME_OBJECT', -1000, event => {
         this.gameCharacters = this.objectStore.getObjects<GameCharacter>(GameCharacter);
+        if (this.gameCharacter && !this.isAccessibleCharacter(this.gameCharacter)) {
+          this.gameCharacter = null;
+          this.sender = this.myPeer.identifier;
+        }
       }).on('CLOSE_OTHER_PEER', event => {
         let object = this.objectStore.get(this.sendTo);
         if (object instanceof PeerCursor && object.peerId === event.data.peer) {


### PR DESCRIPTION
# 概要
チャットウィンドウの送信元のキャラクター選択において、墓場および他人の個人インベントリ内のキャラクターを選択できないようにする機能です。
テスト環境: http://yoshis-islands.sakura.ne.jp/udondev/

# 目的
現状では、チャットウィンドウにて全てのキャラクターが選択可能になっています。
* バージョン: v1.5.1
* 確認日時: 2018年8月5日16時ごろ http://udon.webcrow.jp/

しかし、キャラクター管理はインベントリにて行うように想定していると思われるので、他人の個人インベントリのキャラクターの存在をチャットウィンドウのキャラ選択から知れるような造りは好ましくないと思います。
また、墓場にいるキャラクターは「何らかの理由でゲームから除外されている状態」（主に戦闘不能や死亡など）であるはずなので、チャットから発言できなくする方が使用感が良いと思います。

# 備考
* 共通インベントリや自分の個人インベントリのキャラクターを選択できる方が使い勝手がよいのか否かについては判別つかなかったため、選択できるように実装しています。
* チャットウィンドウにて選択可能か否かの判定は、インベントリの状態に同期させるのが良いと思われるので、処理を共通化したほうが良いのかもしれません。
https://github.com/TK11235/udonarium/blob/master/src/app/component/game-object-inventory/game-object-inventory.component.ts#L74-L95