### PR TITLE
macのchromeで改行後に変換を確定した際にメッセージが送信されるバグを修正

### DIFF
--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -262,10 +262,12 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     });
   }
 
-  sendChat(event: Event) {
+  sendChat(event: KeyboardEvent) {
     if (event) event.preventDefault();
 
     if (!this.text.length) return;
+
+    if (event.keyCode !== 13) return;
 
     if (!this.sender.length) this.sender = this.network.peerId;
 

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -267,7 +267,7 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
     if (!this.text.length) return;
 
-    if (event.keyCode !== 13) return;
+    if (event && event.keyCode !== 13) return;
 
     if (!this.sender.length) this.sender = this.network.peerId;
 


### PR DESCRIPTION
# 概要

macのchromeでenter+shiftで改行をしたのち、日本語を入力して確定のためenterキーを押下するとメッセージが送信される状態になっておりました。
取り急ぎ、入力内容の確定ではメッセージを送信しないように修正いたしました。

# 備考

念のためmacのchrome以外のブラウザで問題がないか確認するため
* macのfirefox
* windowsのedge
* windowsのchrome

で動作を確認しております。

お手数をおかけしますが、よろしくお願いいたします。