### PR TITLE
カード作成時の「トランプ」を「カードデッキ」に変更

### DIFF
--- a/src/app/component/game-table/game-table.component.ts
+++ b/src/app/component/game-table/game-table.component.ts
@@ -340,7 +340,7 @@ export class GameTableComponent implements OnInit, OnDestroy, AfterViewInit {
           }
         },
         {
-          name: 'トランプの山札を作る', action: () => {
+          name: 'カードデッキを作る', action: () => {
             this.createTrump(potison);
             SoundEffect.play(PresetSound.cardPut);
           }


### PR DESCRIPTION
## 趣旨

現状のトランプ機能はカード画像を変更すればあらゆるカード束を表現できますが、
#22 にてlinelingさんが「トランプとあるため画像変更は無理かと勘違い」と仰っており、私も混乱したことがあるため、
あらゆるカード束を表現できることをわかりやすくする為に、カード束の種類を問わない「カードデッキ」の語への変更を提案します。

## 悩んでいる点

現状の「トランプの山札を作る」ボタンを押した際に現れるのは間違いなくトランプの山札である為、この変更自体の合理性に自分でも少々疑問を感じています。逆にわかりにくくなりはしないかと。

カード機能自体のUI改善案を思いつきそうな気がしているので、このままもう少し考えてみるつもりですが、ひとまず文言変更の提案として見ていただければと思います。

よろしくお願いします。