### PR TITLE
カード一覧にカード編集ボタンを追加

### DIFF
--- a/src/app/component/card-stack-list/card-stack-list.component.html
+++ b/src/app/component/card-stack-list/card-stack-list.component.html
@@ -7,8 +7,10 @@
     <div style="display: inline-block;">
       <button type="submit" (click)="drawCard(card)">山札から抜き出す</button>
       <br>
-      <button (click)="up(card)">上へ</button>
-      <button (click)="down(card)">下へ</button>
+      <button (click)="up(card)">↑</button>
+      <button (click)="down(card)">↓</button>
+      <br>
+      <button (click)="showDetail(card)">カードを編集</button>
     </div>
   </div>
 </div>

--- a/src/app/component/card-stack-list/card-stack-list.component.ts
+++ b/src/app/component/card-stack-list/card-stack-list.component.ts
@@ -5,7 +5,9 @@ import { CardStack } from '@udonarium/card-stack';
 import { EventSystem, Network } from '@udonarium/core/system/system';
 import { PresetSound, SoundEffect } from '@udonarium/sound-effect';
 
-import { PanelService } from 'service/panel.service';
+import { GameCharacterSheetComponent } from 'component/game-character-sheet/game-character-sheet.component';
+
+import { PanelOption, PanelService } from 'service/panel.service';
 
 @Component({
   selector: 'card-stack-list',
@@ -79,5 +81,15 @@ export class CardStackListComponent implements OnInit {
       SoundEffect.play(PresetSound.cardShuffle);
     }
     this.panelService.close();
+  }
+
+  private showDetail(gameObject: Card) {
+    let coordinate = {
+      x: this.panelService.left,
+      y: this.panelService.top
+    };
+    let option: PanelOption = { left: coordinate.x + 10, top: coordinate.y + 20, width: 600, height: 600 };
+    let component = this.panelService.open<GameCharacterSheetComponent>(GameCharacterSheetComponent, option);
+    component.tabletopObject = gameObject;
   }
 }


### PR DESCRIPTION
安直ですが、カード一覧パネルにカード編集ボタンを追加してみました。
#28 でTK11235さんが仰っていた

- カードの絵柄やサイズを自由に編集できることの説明

として使えるでしょうか。
ちょっとゴテゴテしてしまったかと思い「上へ」「下へ」ボタンを記号化しています。
ご検討いただければと思います。よろしくお願いします。

## 余談

- 任意の画像群から山札を作成する機能

の方ですが、「画像一覧パネルから画像を複数選択して山札を作成」などというUIは技術的・方針的に可能なものでしょうか。

山札作成以外に、キャラ作成パネルでも「画像を複数選択して作成」機能はある程度有用に思います。ダイス目トークンなどが欲しい時に、関連画像を複数選択して一度にキャラやマスクを作成できれば便利かもしれない、と。

キャラ作成パネルに山札作成ボタンも一緒に置き、画像を複数選択した際に

- 「キャラ作成」や「マスク作成」を押せばそれぞれの画像のキャラやマスクを作成
- 「山札作成」を押せば山札をひとつ作成

ですとか。
いかがでしょうか…。