### PR TITLE
テーブルのstickToGridをオフにする機能

### DIFF
--- a/src/app/class/game-table.ts
+++ b/src/app/class/game-table.ts
@@ -29,7 +29,6 @@ export class GameTable extends ObjectNode implements InnerXml {
   @SyncVar() selected: boolean = false;
   @SyncVar() gridType: GridType = GridType.SQUARE;
   @SyncVar() gridColor: string = '#000000e6';
-  @SyncVar() gridStick: boolean = true;
 
   get terrains(): Terrain[] {
     let terrains: Terrain[] = [];

--- a/src/app/class/game-table.ts
+++ b/src/app/class/game-table.ts
@@ -29,6 +29,7 @@ export class GameTable extends ObjectNode implements InnerXml {
   @SyncVar() selected: boolean = false;
   @SyncVar() gridType: GridType = GridType.SQUARE;
   @SyncVar() gridColor: string = '#000000e6';
+  @SyncVar() gridStick: boolean = true;
 
   get terrains(): Terrain[] {
     let terrains: Terrain[] = [];

--- a/src/app/class/table-selecter.ts
+++ b/src/app/class/table-selecter.ts
@@ -8,6 +8,7 @@ import { GameTable } from './game-table';
 export class TableSelecter extends GameObject {
   @SyncVar() viewTableIdentifier: string = '';
   gridShow: boolean = false; // true=常時グリッド表示
+  gridStick: boolean = true;
 
   initialize(needUpdate: boolean = true) {
     super.initialize(needUpdate);

--- a/src/app/component/game-table-setting/game-table-setting.component.html
+++ b/src/app/component/game-table-setting/game-table-setting.component.html
@@ -37,13 +37,13 @@
           <option value="#000000e6">黒</option>
           <option value="#dddddde6">白</option>
         </select>
-        スナップ:
-        <input type="checkbox" [(ngModel)]="tableGridStick" name="tableGridStick" />
       </div>
       <hr/>
       <div>
         グリッドを常に表示:
         <input type="checkbox" [(ngModel)]="tableGridShow" name="tableGridShow" />
+        スナップ:
+        <input type="checkbox" [(ngModel)]="tableGridStick" name="tableGridStick" />
         <ng-container *ngIf="!isDeleted">
           <button (click)="save()">保存</button>
           <button class="danger" (click)="delete()" [attr.disabled]="getGameTables().length <= 1 ? '' : null">削除</button>

--- a/src/app/component/game-table-setting/game-table-setting.component.html
+++ b/src/app/component/game-table-setting/game-table-setting.component.html
@@ -37,6 +37,8 @@
           <option value="#000000e6">黒</option>
           <option value="#dddddde6">白</option>
         </select>
+        スナップ:
+        <input type="checkbox" [(ngModel)]="tableGridStick" name="tableGridStick" />
       </div>
       <hr/>
       <div>

--- a/src/app/component/game-table-setting/game-table-setting.component.ts
+++ b/src/app/component/game-table-setting/game-table-setting.component.ts
@@ -39,6 +39,9 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
   get tableGridColor(): string { return this.selectedTable.gridColor; }
   set tableGridColor(tableGridColor: string) { if (this.isEditable) this.selectedTable.gridColor = tableGridColor; }
 
+  get tableGridStick(): boolean { return this.selectedTable.gridStick; }
+  set tableGridStick(tableGridStick: boolean) { if (this.isEditable) this.selectedTable.gridStick = tableGridStick; }
+
   get tableGridShow(): boolean { return this.tableSelecter.gridShow; }
   set tableGridShow(tableGridShow: boolean) {
     this.tableSelecter.gridShow = tableGridShow;

--- a/src/app/component/game-table-setting/game-table-setting.component.ts
+++ b/src/app/component/game-table-setting/game-table-setting.component.ts
@@ -39,12 +39,15 @@ export class GameTableSettingComponent implements OnInit, OnDestroy, AfterViewIn
   get tableGridColor(): string { return this.selectedTable.gridColor; }
   set tableGridColor(tableGridColor: string) { if (this.isEditable) this.selectedTable.gridColor = tableGridColor; }
 
-  get tableGridStick(): boolean { return this.selectedTable.gridStick; }
-  set tableGridStick(tableGridStick: boolean) { if (this.isEditable) this.selectedTable.gridStick = tableGridStick; }
-
   get tableGridShow(): boolean { return this.tableSelecter.gridShow; }
   set tableGridShow(tableGridShow: boolean) {
     this.tableSelecter.gridShow = tableGridShow;
+    this.tableSelecter.update();
+  }
+
+  get tableGridStick(): boolean { return this.tableSelecter.gridStick; }
+  set tableGridStick(tableGridStick: boolean) {
+    this.tableSelecter.gridStick = tableGridStick;
     this.tableSelecter.update();
   }
 

--- a/src/app/directive/movable.directive.ts
+++ b/src/app/directive/movable.directive.ts
@@ -165,23 +165,23 @@ export class MovableDirective extends Grabbable implements OnInit, OnDestroy, Af
   }
 
   protected onMouseUp(e: PointerEvent) {
-    let viewTable = ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;
+    let tableSelecter = ObjectStore.instance.get<TableSelecter>('tableSelecter');
 
     if (this.isDisable) return this.cancel();
     e.preventDefault();
     if (this.isDragging) this.ondragend.emit(e);
     this.cancel();
-    if (viewTable.gridStick) this.stickToGrid();
+    if (tableSelecter.gridStick) this.stickToGrid();
     this.onend.emit(e);
   }
 
   protected onContextMenu(e: PointerEvent) {
-    let viewTable = ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;
+    let tableSelecter = ObjectStore.instance.get<TableSelecter>('tableSelecter');
 
     if (this.isDisable) return this.cancel();
     e.preventDefault();
     this.cancel();
-    if (viewTable.gridStick) this.stickToGrid();
+    if (tableSelecter.gridStick) this.stickToGrid();
   }
 
   private calcLocalCoordinate(target: HTMLElement): PointerCoordinate {

--- a/src/app/directive/movable.directive.ts
+++ b/src/app/directive/movable.directive.ts
@@ -1,7 +1,9 @@
 import { AfterViewInit, Directive, ElementRef, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
 
 import { EventSystem } from '@udonarium/core/system/system';
+import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
 import { TabletopObject } from '@udonarium/tabletop-object';
+import { TableSelecter } from '@udonarium/table-selecter';
 
 import { PointerCoordinate, PointerDeviceService } from 'service/pointer-device.service';
 import { TabletopService } from 'service/tabletop.service';
@@ -163,19 +165,23 @@ export class MovableDirective extends Grabbable implements OnInit, OnDestroy, Af
   }
 
   protected onMouseUp(e: PointerEvent) {
+    let viewTable = ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;
+
     if (this.isDisable) return this.cancel();
     e.preventDefault();
     if (this.isDragging) this.ondragend.emit(e);
     this.cancel();
-    this.stickToGrid();
+    if (viewTable.gridStick) this.stickToGrid();
     this.onend.emit(e);
   }
 
   protected onContextMenu(e: PointerEvent) {
+    let viewTable = ObjectStore.instance.get<TableSelecter>('tableSelecter').viewTable;
+
     if (this.isDisable) return this.cancel();
     e.preventDefault();
     this.cancel();
-    this.stickToGrid();
+    if (viewTable.gridStick) this.stickToGrid();
   }
 
   private calcLocalCoordinate(target: HTMLElement): PointerCoordinate {


### PR DESCRIPTION
現状のテーブルではグリッドにキャラクターコマやマップマスクが吸着しますが、これをオフにする設定項目の機能です。

グリッドにぴったり沿ったマップを使用している場合、スナップすると配置しやすく非常に遊びやすいです。
しかし、すべてのTRPGやボードゲームがグリッド沿いマップでできているわけではないため、ものによってはプレイに支障をきたすレベルであらぬ場所にスナップしてしまうケースがあります。
これを解決することを目的としています。

よろしくお願いします。

## 悩んでいる点
周りのグリッド系変数の文字数に近くなるため、変数名を `gridStick` としていますが、あまりよい命名でない気もしています。
かといってよりよい案も思いつけずそのままになっています…。

また、私はこの手の吸着機能の名前は「スナップ」だと思いこんできたために、UI文言ではそう表現しています。ですが、コードに合わせ「スティック」や「吸着」などにしたほうがよかったかと悩んでいます。
CSSの `position:sticky` などもありますしstickは説得力ある語だと思います。コード中のstickを変えたほうがいいのでは、とは思っていません。
ただ、「スナップ」という語も初めて目にしたとき大変困惑したのを覚えているため、ユーザーにとって馴染みやすい表現がどんなものか迷っています。

UI自体も改善の余地が大いにあると考えていますが、後の改修の際に一緒に考えればいいかなと思いそのままになっています…。