### PR TITLE
チャットパレットの高さを変更できるようにする機能

### DIFF
--- a/src/app/component/chat-palette/chat-palette.component.css
+++ b/src/app/component/chat-palette/chat-palette.component.css
@@ -32,6 +32,9 @@
   box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Verdana, Meiryo, sans-serif;
 }
+.palette option {
+  height: 20px;
+}
 .direct-message {
   background-color: #555;
   color: #CCC;

--- a/src/app/component/chat-palette/chat-palette.component.css
+++ b/src/app/component/chat-palette/chat-palette.component.css
@@ -34,9 +34,6 @@
   width: 100%;
   height: 100%;
 }
-.palette option {
-  height: 20px;
-}
 .direct-message {
   background-color: #555;
   color: #CCC;

--- a/src/app/component/chat-palette/chat-palette.component.css
+++ b/src/app/component/chat-palette/chat-palette.component.css
@@ -53,3 +53,20 @@
   word-break: break-all;
   vertical-align: bottom;
 }
+
+.sticky-top {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background-color: rgba(240, 218, 189, 0.8);
+  border-bottom: 1px dotted #666;
+  margin-top: 0px;
+}
+.sticky-bottom {
+  position: sticky;
+  bottom: 0;
+  width: 100%;
+  background-color: rgba(240, 218, 189, 0.8);
+  border-top: 1px dotted #666;
+  margin-bottom: 0;
+}

--- a/src/app/component/chat-palette/chat-palette.component.css
+++ b/src/app/component/chat-palette/chat-palette.component.css
@@ -31,6 +31,8 @@
 /*.input {*/
   box-sizing: border-box;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Verdana, Meiryo, sans-serif;
+  width: 100%;
+  height: 100%;
 }
 .palette option {
   height: 20px;
@@ -57,19 +59,8 @@
   vertical-align: bottom;
 }
 
-.sticky-top {
-  position: sticky;
-  top: 0;
-  width: 100%;
-  background-color: rgba(240, 218, 189, 0.8);
-  border-bottom: 1px dotted #666;
-  margin-top: 0px;
-}
-.sticky-bottom {
-  position: sticky;
-  bottom: 0;
-  width: 100%;
-  background-color: rgba(240, 218, 189, 0.8);
-  border-top: 1px dotted #666;
-  margin-bottom: 0;
+.flex-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -33,7 +33,7 @@
   <div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
 </div>
 <div *ngIf="!isEdit">
-  <select class="palette" style="width: 100%;" [size]="paletteSize" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
+  <select class="palette" style="width: 100%; overflow: hidden;" [size]="paletteSize" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
     <ng-container *ngIf="palette">
       <option *ngFor="let palette of palette.getPalette()" value="{{palette}}">{{palette}}</option>
     </ng-container>

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -1,46 +1,50 @@
-<div class="table" [ngClass]="{'direct-message': isDirect}">
-  <div class="table-cell imagebox">
-    <img class="image" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
-    />
-  </div>
-  <div class="table-cell">
-    <div>
-      <select style="width: 8em;" [(ngModel)]="chatTabidentifier" [ngModelOptions]="{standalone: true}">
-        <option *ngFor="let chatTab of chatMessageService.chatTabs" value="{{chatTab.identifier}}">{{chatTab.name}}</option>
+<div class="sticky-top">
+  <div class="table" [ngClass]="{ 'direct-message': isDirect }">
+    <div class="table-cell imagebox">
+      <img class="image" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
+      />
+    </div>
+    <div class="table-cell">
+      <div>
+        <select style="width: 8em;" [(ngModel)]="chatTabidentifier" [ngModelOptions]="{standalone: true}">
+          <option *ngFor="let chatTab of chatMessageService.chatTabs" value="{{chatTab.identifier}}">{{chatTab.name}}</option>
         </select>
-      <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
-        <option value="">ダイスボット指定なし</option>
-        <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
-      </select>
-      <button (click)="showDicebotHelp()">?</button>
-      <br>
-      <span>{{character.name}}</span> ＞
-      <select style="width: 10em;" [(ngModel)]="sendTo">
-        <option value="">全員</option>
-        <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}<ng-container *ngIf="peer === myPeer">（あなた）</ng-container></option>
-      </select>
-    </div>
-    <div>
-      <form>
-        <!--<input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" style="width: 25em;">-->
-        <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
-        <button type="submit" (click)="sendChat(null)">SEND</button>
-      </form>
+        <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
+          <option value="">ダイスボット指定なし</option>
+          <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
+        </select>
+        <button (click)="showDicebotHelp()">?</button>
+        <br>
+        <span>{{character.name}}</span> ＞
+        <select style="width: 10em;" [(ngModel)]="sendTo">
+          <option value="">全員</option>
+          <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}<ng-container *ngIf="peer === myPeer">（あなた）</ng-container></option>
+        </select>
+      </div>
+      <div>
+        <form>
+          <!--<input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" style="width: 25em;">-->
+          <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
+          <button type="submit" (click)="sendChat(null)">SEND</button>
+        </form>
+      </div>
     </div>
   </div>
+  <div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
 </div>
 <div *ngIf="!isEdit">
-  <select class="palette" style="width: 100%;" size="8" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
+  <select class="palette" style="width: 100%;" [size]="paletteSize" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
     <ng-container *ngIf="palette">
       <option *ngFor="let palette of palette.getPalette()" value="{{palette}}">{{palette}}</option>
     </ng-container>
   </select>
 </div>
-<div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
 <div *ngIf="isEdit">
-  <textarea class="palette" style="width: 100%; height: 10rem; resize: none;" [(ngModel)]="editPalette" placeholder="チャットパレット"></textarea>
+  <textarea class="palette" style="width: 100%; resize: none;" [style.height.px]="paletteSize * 20" [(ngModel)]="editPalette" placeholder="チャットパレット"></textarea>
 </div>
-<button type="submit" (click)="toggleEditMode()">
-  <span *ngIf="!isEdit">チャットパレットの編集</span>
-  <span *ngIf="isEdit">チャットパレットを確定</span>
-</button>
+<div class="sticky-bottom">
+  <button type="submit" (click)="toggleEditMode()">
+    <span *ngIf="!isEdit">チャットパレットの編集</span>
+    <span *ngIf="isEdit">チャットパレットを確定</span>
+  </button>
+</div>

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -1,50 +1,52 @@
-<div class="sticky-top">
-  <div class="table" [ngClass]="{ 'direct-message': isDirect }">
-    <div class="table-cell imagebox">
-      <img class="image" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
-      />
-    </div>
-    <div class="table-cell">
-      <div>
-        <select style="width: 8em;" [(ngModel)]="chatTabidentifier" [ngModelOptions]="{standalone: true}">
-          <option *ngFor="let chatTab of chatMessageService.chatTabs" value="{{chatTab.identifier}}">{{chatTab.name}}</option>
-        </select>
-        <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
-          <option value="">ダイスボット指定なし</option>
-          <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
-        </select>
-        <button (click)="showDicebotHelp()">?</button>
-        <br>
-        <span>{{character.name}}</span> ＞
-        <select style="width: 10em;" [(ngModel)]="sendTo">
-          <option value="">全員</option>
-          <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}<ng-container *ngIf="peer === myPeer">（あなた）</ng-container></option>
-        </select>
+<div class="flex-container">
+  <div style="flex-grow: 0;">
+    <div class="table" [ngClass]="{ 'direct-message': isDirect }">
+      <div class="table-cell imagebox">
+        <img class="image" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
+        />
       </div>
-      <div>
-        <form>
-          <!--<input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" style="width: 25em;">-->
-          <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
-          <button type="submit" (click)="sendChat(null)">SEND</button>
-        </form>
+      <div class="table-cell">
+        <div>
+          <select style="width: 8em;" [(ngModel)]="chatTabidentifier" [ngModelOptions]="{standalone: true}">
+            <option *ngFor="let chatTab of chatMessageService.chatTabs" value="{{chatTab.identifier}}">{{chatTab.name}}</option>
+          </select>
+          <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
+            <option value="">ダイスボット指定なし</option>
+            <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
+          </select>
+          <button (click)="showDicebotHelp()">?</button>
+          <br>
+          <span>{{character.name}}</span> ＞
+          <select style="width: 10em;" [(ngModel)]="sendTo">
+            <option value="">全員</option>
+            <option *ngFor="let peer of otherPeers" value="{{peer.identifier}}">{{peer.name}}<ng-container *ngIf="peer === myPeer">（あなた）</ng-container></option>
+          </select>
+        </div>
+        <div>
+          <form>
+            <!--<input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" style="width: 25em;">-->
+            <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
+            <button type="submit" (click)="sendChat(null)">SEND</button>
+          </form>
+        </div>
       </div>
     </div>
+    <div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
   </div>
-  <div *ngIf="isEdit" class="edit-info"><i class="material-icons" style="vertical-align: bottom; size:0.8rem;">info_outline</i> チャットパレット編集中です</div>
-</div>
-<div *ngIf="!isEdit">
-  <select class="palette" style="width: 100%; overflow: hidden;" [size]="paletteSize" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
-    <ng-container *ngIf="palette">
-      <option *ngFor="let palette of palette.getPalette()" value="{{palette}}">{{palette}}</option>
-    </ng-container>
-  </select>
-</div>
-<div *ngIf="isEdit">
-  <textarea class="palette" style="width: 100%; resize: none;" [style.height.px]="paletteSize * 20" [(ngModel)]="editPalette" placeholder="チャットパレット"></textarea>
-</div>
-<div class="sticky-bottom">
-  <button type="submit" (click)="toggleEditMode()">
-    <span *ngIf="!isEdit">チャットパレットの編集</span>
-    <span *ngIf="isEdit">チャットパレットを確定</span>
-  </button>
+  <div *ngIf="!isEdit" style="flex-grow: 1; height: 0; min-height: 100px;">
+    <select class="palette" style="overflow-y: auto;" [size]="paletteSize" (click)="selectPalette($event.target.value)" (doubleclick)="sendChat()">
+      <ng-container *ngIf="palette">
+        <option *ngFor="let palette of palette.getPalette()" value="{{palette}}">{{palette}}</option>
+      </ng-container>
+    </select>
+  </div>
+  <div *ngIf="isEdit" style="flex-grow: 1; height: 0; min-height: 100px;">
+    <textarea class="palette" style="resize: none;" [(ngModel)]="editPalette" placeholder="チャットパレット"></textarea>
+  </div>
+  <div style="flex-grow: 0;">
+    <button type="submit" (click)="toggleEditMode()">
+      <span *ngIf="!isEdit">チャットパレットの編集</span>
+      <span *ngIf="isEdit">チャットパレットを確定</span>
+    </button>
+  </div>
 </div>

--- a/src/app/component/chat-palette/chat-palette.component.ts
+++ b/src/app/component/chat-palette/chat-palette.component.ts
@@ -39,6 +39,8 @@ export class ChatPaletteComponent implements OnInit {
   isEdit: boolean = false;
   editPalette: string = '';
 
+  get paletteSize(): number { return this.palette.getPalette().length > 5 ? this.palette.getPalette().length : 5; }
+
   private writingEventInterval: NodeJS.Timer = null;
   private previousWritingLength: number = 0;
 

--- a/src/app/component/chat-palette/chat-palette.component.ts
+++ b/src/app/component/chat-palette/chat-palette.component.ts
@@ -39,7 +39,7 @@ export class ChatPaletteComponent implements OnInit {
   isEdit: boolean = false;
   editPalette: string = '';
 
-  get paletteSize(): number { return this.palette.getPalette().length > 5 ? this.palette.getPalette().length : 5; }
+  get paletteSize(): number { return this.palette.getPalette().length > 2 ? this.palette.getPalette().length : 2; }
 
   private writingEventInterval: NodeJS.Timer = null;
   private previousWritingLength: number = 0;


### PR DESCRIPTION

テスト環境: http://yoshis-islands.sakura.ne.jp/udondev/

※以下にある「既知の問題」を解決する方策が思いつかなかったため、知恵をお借りしたいです。

# 実装理由
チャットパレットに多くのコマンドを用意していた場合、
現状では8行分しか表示されないため、
目的のチャットパレットを探すのに不便だったため。

# 実装方針
- チャットパレットの高さを、チャットパレットの行数に合わせて変動するように
- パネルからはみ出す場合は、送信部分や編集ボタンは固定してスクロールするように（チャットウィンドウの表示方法を参考にしました）

# 既知の問題
## チャットパレット編集中に2重にスクロールバーが表示されてしまう
チャットパレット編集中の`<textarea>`の高さは、編集前のチャットパレットサイズを元に設定しています。
そのため、その高さを超えるチャットパレットを入力すると、チャットパレットtextareaと外のパネルの2つのスクロールバーが表示されてしまい具合が悪いです。
`ChatPaletteComponent#calcFitHeight`のようにチャットパレットtextareaの高さを調節すれば良いと思うのですが、上手く実装できませんでした。
![default](https://user-images.githubusercontent.com/7685946/48658255-1e4fe280-ea82-11e8-8a65-c866c5037a49.png)


## チャットパレットを選択したときに、Chromeなどで勝手にスクロールされてしまう
チャットパレットの高さがパネルからはみ出しているときに、チャットパレットの最上部のoptionや最下部のoptionをクリックしたときに、
`<select>`部が勝手にスクロールされてしまい、目的としないチャットパレットが選択されてしまいます。
どうやら`position: sticky;`と`select`を併用したときのブラウザの挙動のようです。Firefoxでは発生しません。
https://stackoverflow.com/questions/50804028/position-sticky-jumps-when-selecting-option
一度チャットパレットをクリックして、続けてクリックする場合には発生しません。
