### PR TITLE
ルーム機能を使用したときに、開いていたインベントリに共有タブが複数発生してしまう状況の修正

### DIFF
--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -64,6 +64,12 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
       })
       .on('UPDATE_INVENTORY', event => {
         if (event.isSendFromSelf) this.changeDetector.markForCheck();
+      })
+      .on('OPEN_PEER', event => {
+        this.inventoryTypes = ['table', 'common', Network.peerId, 'graveyard'];
+        if (!this.inventoryTypes.includes(this.selectTab)) {
+          this.selectTab = Network.peerId;
+        }
       });
     this.inventoryTypes = ['table', 'common', Network.peerId, 'graveyard'];
   }


### PR DESCRIPTION
# 現象
- インベントリを開いていたときに「新しいルームを作成」または「ルームへの接続」をしたときに、個人インベントリが共有インベントリとなってしまう。
![9ad263fa-122a-468c-95b3-4d38616885ad png](https://user-images.githubusercontent.com/7685946/53809361-e1a7e880-3f97-11e9-850c-45d9033789e0.jpg)
(左がルーム作成前から開いていたインベントリ。右はルーム作成後に開いたインベントリ)
(キャラクターAはルーム作成後に個人インベントリへ移動させた)

- バージョン：v1.8.4
- 確認日時： 2019年3月5日22時半頃 https://udonarium.app/

# 再現手順
1. インベントリを開く
2. ロビーから「新しいルームを作成する」またはルームへの「接続する」ボタンを押す

# 原因
`GameObjectInventoryComonent`の個人インベントリの`inventoryType`が、インベントリを開いたときの自分のpeerIDとなっているが、
ルーム機能を使う場合に新しいpeerIDが生成されるため、
古いpeerIDのままだと個人インベントリと認識されない。

# このPRで行った修正
- 自分のpeerIDが変わるときの`OPEN_PEER`イベントに合わせて、インベントリの`inventoryTypes`を更新する
- 個人インベントリを選択していた場合、`selectedTab`を新しいpeerIDに変更する
