### PR TITLE
墓場インベントリの全削除機能

### DIFF
--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -6,6 +6,9 @@
     (click)="selectGameObject(gameObject)" [ngClass]="{'box': true, 'selected': (selectedIdentifier === gameObject.identifier)}">
     <ng-container *ngTemplateOutlet="gameObjectTags; context:{ gameObject: gameObject}"></ng-container>
   </div>
+  <div *ngIf="selectTab === 'graveyard'" style="padding-top: 6px;">
+    <button class="danger" (click)="cleanInventory()" [attr.disabled]="getGameObjects(selectTab).length < 1 ? '' : null">墓場を空にする</button>
+  </div>
 </div>
 <ng-template #inventoryTab>
   <form class="is-sticky-top">

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -170,6 +170,13 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
     this.isEdit = !this.isEdit;
   }
 
+  cleanInventory() {
+    for (const gameObject of this.getGameObjects(this.selectTab)) {
+      this.deleteGameObject(gameObject);
+    }
+    SoundEffect.play(PresetSound.sweep);
+  }
+
   private cloneGameObject(gameObject: TabletopObject) {
     gameObject.clone();
   }


### PR DESCRIPTION
# 概要
墓場インベントリに存在するキャラクターを一気に削除する機能です。
テスト環境: http://yoshis-island.net/udondev/

# 目的
現状(v1.9.1)の機能だと、キャラクターの削除をするためには

1. 墓場インベントリに移動
1. 右クリックから「削除する」

の手順を踏まなければなりません。

この手順で大量のキャラを削除するのは非常に手間な上、
右クリックメニューの「削除する」の近くに
インベントリの移動があるため、
削除したかったのに移動させてしまうことがたまにありました。

上記の手間を減らすための機能です。

# 懸念点
簡単に削除できてしまうため、誤操作で墓場を空にしてしまうことが予想されます。
削除してしまう前にアラートを出すか、
削除後に元に戻す機能を用意するかした方がいい気がします。
どちらが良いかは決めかねています。

