### PR TITLE
feat:ダイス固定・固定解除の追加 #67

### DIFF
--- a/src/app/class/dice-symbol.ts
+++ b/src/app/class/dice-symbol.ts
@@ -21,6 +21,7 @@ export class DiceSymbol extends TabletopObject {
   @SyncVar() face: string = '0';
   @SyncVar() owner: string = '';
   @SyncVar() rotate: number = 0;
+  @SyncVar() isLock: boolean = false;
 
   get name(): string { return this.getCommonValue('name', ''); }
   set name(name: string) { this.setCommonValue('name', name); }

--- a/src/app/component/dice-symbol/dice-symbol.component.ts
+++ b/src/app/component/dice-symbol/dice-symbol.component.ts
@@ -66,6 +66,8 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
   set owner(owner: string) { this.diceSymbol.owner = owner; }
   get rotate(): number { return this.diceSymbol.rotate; }
   set rotate(rotate: number) { this.diceSymbol.rotate = rotate; }
+  get isLock(): boolean { return this.diceSymbol.isLock; }
+  set isLock(isLock: boolean) { this.diceSymbol.isLock = isLock; }
 
   get name(): string { return this.diceSymbol.name; }
   set name(name: string) { this.diceSymbol.name = name; }
@@ -169,7 +171,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
     this.doubleClickTimer = null;
     if (this.doubleClickPoint.x === this.pointerDeviceService.pointers[0].x
       && this.doubleClickPoint.y === this.pointerDeviceService.pointers[0].y) {
-      if (this.isVisible) this.diceRoll();
+      if (this.isVisible && !this.isLock) this.diceRoll();
     }
   }
 
@@ -183,7 +185,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
 
     let actions: ContextMenuAction[] = [];
 
-    if (this.isVisible) {
+    if (this.isVisible && !this.isLock) {
       actions.push({
         name: 'ダイスを振る', action: () => {
           this.diceRoll();
@@ -208,7 +210,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
       });
     }
 
-    if (this.isVisible) {
+    if (this.isVisible && !this.isLock) {
       let subActions: ContextMenuAction[] = [];
       this.faces.forEach(face => {
         subActions.push({
@@ -219,6 +221,23 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
         });
       });
       actions.push({ name: `ダイス目を設定`, action: null, subActions: subActions });
+    }
+
+    if(this.isLock) {
+      actions.push({
+        name: 'ダイス目を固定解除', action: () => {
+          this.isLock = false;
+          SoundEffect.play(PresetSound.unlock);
+        }
+      });
+    }
+    if(!this.isLock) {
+      actions.push({
+        name: 'ダイス目を固定', action: () => {
+          this.isLock = true;
+          SoundEffect.play(PresetSound.lock);
+        }
+      });
     }
 
     actions.push(ContextMenuSeparator);


### PR DESCRIPTION
### 概要
ダイスのメニューから、ダイスの出目を固定・固定解除する機能を追加しました。

### 詳細

1. ダイスのプロパティに「isLock」を追加（デフォルト：false）
2. isLock=falseの時はメニューに「ダイス目を固定」が表示され、選択するとisLock=trueに更新
3. isLock=trueの間は、ダブルクリック・「ダイスを振る」・「ダイス目を設定」を実行できなくする
4. isLock=trueの時はメニューに「ダイス目を固定解除」が表示され、選択するとisLock=falseに更新

### 懸念点
- #67 に記載のうち、ダブルクリックでダイス目が変わってしまう問題に対処しました。メッセージに関しては非対応です。

- 見た目の変更は現時点ではありません。（マップマスクと同じく、ダイスの上に鍵マークをつけようと思いましたが、うまくダイスにかぶるよう配置ができませんでした）

- ダイス目を固定した状態でダイスのメニューを開いたときに、罫線が2つ連続で表示されます。

### その他
プログラミングやGithubの利用に慣れていないため、不自然な箇所あるかもしれません。
その際はコメントいただけると助かります。