### PR TITLE
feat:メニューに「カードを作る」を追加

### DIFF
--- a/src/app/service/tabletop.service.ts
+++ b/src/app/service/tabletop.service.ts
@@ -312,6 +312,24 @@ export class TabletopService {
     return cardStack;
   }
 
+  createCard(position: PointerCoordinate):Card {
+    let front_url: string = './assets/images/trump/x01.gif';
+    if (!ImageStorage.instance.get(front_url)) {
+      ImageStorage.instance.add(front_url);
+    }
+
+    let back_url: string = './assets/images/trump/z02.gif';
+    if (!ImageStorage.instance.get(back_url)) {
+      ImageStorage.instance.add(back_url);
+    }
+
+    let card:Card = Card.create('新しいカード',front_url,back_url);
+
+    card.location.x = position.x;
+    card.location.y = position.y;
+    return card;
+  }
+
   makeDefaultTable() {
     let tableSelecter = new TableSelecter('tableSelecter');
     tableSelecter.initialize();
@@ -399,6 +417,7 @@ export class TabletopService {
       this.getCreateTerrainMenu(position),
       this.getCreateTextNoteMenu(position),
       this.getCreateTrumpMenu(position),
+      this.getCreateCardMenu(position),
       this.getCreateDiceSymbolMenu(position),
     ];
   }
@@ -444,6 +463,15 @@ export class TabletopService {
     return {
       name: 'トランプの山札を作成', action: () => {
         this.createTrump(position);
+        SoundEffect.play(PresetSound.cardPut);
+      }
+    }
+  }
+
+  private getCreateCardMenu(position: PointerCoordinate): ContextMenuAction {
+    return {
+      name: 'カードを作成', action: () => {
+        this.createCard(position);
         SoundEffect.play(PresetSound.cardPut);
       }
     }


### PR DESCRIPTION
# 概要
Ver1.9.xに上がって以降、カードは

- 表・裏にそれぞれ画像を設定できる

- 表向きのときだけ、カードの設定項目がポップアップで表示される

といった利点があり、秘密ハンドアウトや情報項目を管理するツールとして利用ができます。
（権限設定がないので、「プレイヤーが勝手に表にしない・編集しない」といった良心は求められますが）

このように便利なカードですが、Ver1.9.3時点での仕様だと「トランプの山札を作成」→「1枚引く」というプロセスでしか生成できず若干もったいない（利用価値があるのに気づきにくい）ので、メニューから直接カードが生成されるよう追加を行いました。

# 詳細
- メニューに「カードを作る」を追加
- デフォルトでは、名前は「新しいカード」、画像はトランプのジョーカーになる

# 懸念点
特にありません。