### PR TITLE
【開発一時凍結】feat: 画像へのタグ付与・タグ検索機能の追加  #56

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -14,6 +14,7 @@ import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
 import { ObjectSynchronizer } from '@udonarium/core/synchronize-object/object-synchronizer';
 import { EventSystem, Network } from '@udonarium/core/system';
 import { DataSummarySetting } from '@udonarium/data-summary-setting';
+import { ImageTagList } from '@udonarium/image-tag-list';
 import { DiceBot } from '@udonarium/dice-bot';
 import { Jukebox } from '@udonarium/Jukebox';
 import { PeerCursor } from '@udonarium/peer-cursor';
@@ -75,6 +76,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     this.pointerDeviceService.initialize();
 
     DataSummarySetting.instance.initialize();
+    ImageTagList.instance.initialize();
 
     let diceBot: DiceBot = new DiceBot('DiceBot');
     diceBot.initialize();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,6 +36,7 @@ import { ModalService } from 'service/modal.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 import { SaveDataService } from 'service/save-data.service';
+import { ImageTag } from '@udonarium/image-tag';
 
 @Component({
   selector: 'app-root',
@@ -98,6 +99,10 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     let fileContext = ImageFile.createEmpty('none_icon').toContext();
     fileContext.url = './assets/images/ic_account_circle_black_24dp_2x.png';
     let noneIconImage = ImageStorage.instance.add(fileContext);
+    let noneIconImageTag = new ImageTag();
+    noneIconImageTag.imageIdentifier = noneIconImage.identifier;
+    noneIconImageTag.tag = 'default';
+    ImageTagList.instance.appendChild(noneIconImageTag);
 
     AudioPlayer.resumeAudioContext();
     PresetSound.dicePick = AudioStorage.instance.add('./assets/sounds/soundeffect-lab/shoulder-touch1.mp3').identifier;

--- a/src/app/class/core/file-storage/file-archiver.ts
+++ b/src/app/class/core/file-storage/file-archiver.ts
@@ -7,6 +7,7 @@ import { AudioStorage } from './audio-storage';
 import { FileReaderUtil } from './file-reader-util';
 import { ImageStorage } from './image-storage';
 import { MimeType } from './mime-type';
+import {ImageTagList} from '../../image-tag-list';
 
 export class FileArchiver {
   private static _instance: FileArchiver
@@ -87,7 +88,9 @@ export class FileArchiver {
     if (file.type.indexOf('image/') < 0) return;
     console.log(file.name + ' type:' + file.type);
     if (2 * 1024 * 1024 < file.size) return;
-    await ImageStorage.instance.addAsync(file);
+
+    let newImage = await ImageStorage.instance.addAsync(file);
+    ImageTagList.instance.pushTag(newImage.identifier);
   }
 
   private async handleAudio(file: File) {

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -1,5 +1,7 @@
 import { EventSystem } from '../system';
 import { ImageContext, ImageFile, ImageState } from './image-file';
+import { ImageTagList } from '../../image-tag-list';
+import { ImageTag} from '../../image-tag';
 
 export type CatalogItem = { identifier: string, state: number };
 
@@ -61,6 +63,12 @@ export class ImageStorage {
     if (this.update(image)) return this.imageHash[image.identifier];
     this.imageHash[image.identifier] = image;
     console.log('addNewFile()', image);
+
+    let imagetag = new ImageTag();
+    imagetag.imageIdentifier = image.identifier;
+    imagetag.tag = image.identifier;
+    ImageTagList.instance.appendChild(imagetag);
+
     return image;
   }
 

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -1,7 +1,5 @@
 import { EventSystem } from '../system';
 import { ImageContext, ImageFile, ImageState } from './image-file';
-import { ImageTagList } from '../../image-tag-list';
-import { ImageTag} from '../../image-tag';
 
 export type CatalogItem = { identifier: string, state: number };
 
@@ -63,11 +61,6 @@ export class ImageStorage {
     if (this.update(image)) return this.imageHash[image.identifier];
     this.imageHash[image.identifier] = image;
     console.log('addNewFile()', image);
-
-    let imagetag = new ImageTag();
-    imagetag.imageIdentifier = image.identifier;
-    imagetag.tag = image.identifier;
-    ImageTagList.instance.appendChild(imagetag);
 
     return image;
   }

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -2,6 +2,7 @@ import { ImageTag } from './image-tag';
 import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
 import { InnerXml } from './core/synchronize-object/object-serializer';
+import { PeerCursor } from './peer-cursor';
 
 @SyncObject('ImageTagList')
 export class ImageTagList extends ObjectNode implements InnerXml {
@@ -14,8 +15,6 @@ export class ImageTagList extends ObjectNode implements InnerXml {
         }
         return ImageTagList._instance;
     }
-    
-    get imageTags(): ImageTag[] {return <ImageTag[]> this.children; }
 
     getMatchTags(searchWord: string) :ImageTag[] {
         let resultTags: ImageTag[] = [];
@@ -36,6 +35,23 @@ export class ImageTagList extends ObjectNode implements InnerXml {
 
         console.log('NotFound Target ImageTag from ImageTagList',ide);
         return null;
+    }
+
+    pushTag(ide:string ,newtag:string = PeerCursor.myCursor.name ) :ImageTag {
+        let retTag =this.getTagFromIdentifier(ide);
+
+        if(retTag == null) {
+            retTag = new ImageTag();
+            retTag.imageIdentifier = ide;
+            retTag.tag = newtag;
+            this.appendChild(retTag);
+            return retTag;
+        }
+
+        if(retTag.tag != newtag) {
+            retTag.tag = newtag;
+        }
+        return retTag;
     }
 
     innerXml(): string { return ''; }

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -29,6 +29,15 @@ export class ImageTagList extends ObjectNode implements InnerXml {
         return resultTags;
     }
 
+    getTagFromIdentifier(ide:string) :ImageTag {
+        for(let target of this.imageTags) {
+            if(target.imageIdentifier == ide) return target;
+        }
+
+        console.log('NotFound Target ImageTag from ImageTagList',ide);
+        return null;
+    }
+
     innerXml(): string { return ''; }
 
     parseInnerXml(element: Element) {

--- a/src/app/class/image-tag-list.ts
+++ b/src/app/class/image-tag-list.ts
@@ -1,0 +1,43 @@
+import { ImageTag } from './image-tag';
+import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
+import { ObjectNode } from './core/synchronize-object/object-node';
+import { InnerXml } from './core/synchronize-object/object-serializer';
+
+@SyncObject('ImageTagList')
+export class ImageTagList extends ObjectNode implements InnerXml {
+    // todo:シングルトン化するのは妥当？
+    private static _instance: ImageTagList;
+    static get instance(): ImageTagList {
+        if (!ImageTagList._instance) {
+        ImageTagList._instance = new ImageTagList('ImageTagList');
+        ImageTagList._instance.initialize();
+        }
+        return ImageTagList._instance;
+    }
+    
+    get imageTags(): ImageTag[] {return <ImageTag[]> this.children; }
+
+    getMatchTags(searchWord: string) :ImageTag[] {
+        let resultTags: ImageTag[] = [];
+
+        for(let target of this.imageTags) {
+            if(target.isContainsWord(searchWord)) {
+                resultTags.push(target);
+            }
+        }
+
+        return resultTags;
+    }
+
+    innerXml(): string { return ''; }
+
+    parseInnerXml(element: Element) {
+      // XMLからの新規作成を許可せず、既存のオブジェクトを更新する
+      let context = ImageTagList.instance.toContext();
+      context.syncData = this.toContext().syncData;
+      ImageTagList.instance.apply(context);
+      ImageTagList.instance.update();
+  
+      this.destroy();
+    }
+}

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -1,0 +1,22 @@
+import { ImageFile } from './core/file-storage/image-file';
+import { ImageStorage } from './core/file-storage/image-storage';
+import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
+import { ObjectNode } from './core/synchronize-object/object-node';
+
+@SyncObject('image-tag')
+export class ImageTag extends ObjectNode {
+    @SyncVar() imageIdentifier: string;
+    @SyncVar() isSave: boolean;
+
+    get tag():string {return <string>this.value; }
+    get image(): ImageFile { return ImageStorage.instance.get(this.imageIdentifier); }
+
+    set tag(tag:string) { this.value = tag; }
+
+    isContainsWord(word: string) :boolean {
+        if(this.tag.indexOf(word) == -1) { return false; }
+        else {return true; }
+    }
+
+    
+}

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -1,15 +1,12 @@
-import { ImageFile } from './core/file-storage/image-file';
-import { ImageStorage } from './core/file-storage/image-storage';
 import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
 import { ObjectNode } from './core/synchronize-object/object-node';
 
 @SyncObject('image-tag')
 export class ImageTag extends ObjectNode {
-    @SyncVar() imageIdentifier: string;
-    @SyncVar() isSave: boolean;
+    @SyncVar() imageIdentifier: string = '';
+    @SyncVar() isSave: boolean = false;
 
     get tag():string {return <string>this.value; }
-    get image(): ImageFile { return ImageStorage.instance.get(this.imageIdentifier); }
 
     set tag(tag:string) { this.value = tag; }
 

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,5 +1,5 @@
 <div id="search">
-  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" /> 
+  検索：  <input [(ngModel)]="searchWd"  placeholder="部分一致で検索" />   <button (click)="searchImageFromTag()">検索</button>
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,3 +1,7 @@
+<div id="search">
+  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" /> 
+</div>
+<hr/>
 <div id="file-list">
   <span class="empty" *ngIf="isAllowedEmpty">
     <button (click)="onSelectedFile(empty)">画像なし</button>

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,5 +1,5 @@
 <div id="search">
-  検索：  <input [(ngModel)]="searchWd"  placeholder="部分一致で検索" />   <button (click)="searchImageFromTag()">検索</button>
+  検索：  <input [(ngModel)]=" searchWord"  placeholder="部分一致で検索" />   <button (click)="searchImageFromTag()">検索</button>
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -21,14 +21,11 @@ import { PanelService } from 'service/panel.service';
 })
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
-  private searchWord:string = 'default';
+  searchWord:string = 'default';
 
   @Input() isAllowedEmpty: boolean = false;
   get images(): ImageFile[] { return ImageStorage.instance.images; }
   get empty(): ImageFile { return ImageFile.Empty; }
-  //以下のget・setは暫定
-  get searchWd(): string { return this.searchWord; }
-  set searchWd(word:string) {this.searchWord = word; }
 
   constructor(
     private changeDetector: ChangeDetectorRef,

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -26,6 +26,9 @@ export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() isAllowedEmpty: boolean = false;
   get images(): ImageFile[] { return ImageStorage.instance.images; }
   get empty(): ImageFile { return ImageFile.Empty; }
+  //以下のget・setは暫定
+  get searchWd(): string { return this.searchWord; }
+  set searchWd(word:string) {this.searchWord = word; }
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -55,5 +58,9 @@ export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
     console.log('onSelectedFile', file);
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
     this.modalService.resolve(file.identifier);
+  }
+
+  searchImageFromTag() {
+    console.log('検索ボタン押下/検索ワード：' + this.searchWord );
   }
 }

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -21,6 +21,8 @@ import { PanelService } from 'service/panel.service';
 })
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
+  private searchWord:string = 'default';
+
   @Input() isAllowedEmpty: boolean = false;
   get images(): ImageFile[] { return ImageStorage.instance.images; }
   get empty(): ImageFile { return ImageFile.Empty; }

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -12,10 +12,10 @@
 </label>
 <hr/>
 <div id="search">
-  検索：  <input [(ngModel)]="searchWd"  placeholder="部分一致で検索" />  <button (click)="searchImageFromTag()">検索</button>
+  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" />  <button (click)="searchImageFromTag()">検索</button>
 </div>
 <div id="edit-tag">
-  選択した画像のタグ：  <input [(ngModel)]="selectedIT"  placeholder="" /> <button (click)="changeTag()">変更</button>
+  選択した画像のタグ：  <input [(ngModel)]="selectedImageTag" (input)="changeTagTextBox()" placeholder="" /> <button id="change-tag-button" (click)="changeTag()" [disabled]="!isTagTextBoxChanged">変更</button>
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -10,6 +10,14 @@
       <br>１ファイルにつき2MBまで</div>
   </div>
 </label>
+<hr/>
+<div id="search">
+  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" /> 
+</div>
+<div id="edit-tag">
+  選択した画像のタグ：  <input [(ngModel)]="selectedImageTag"  placeholder="" /> 
+</div>
+<hr/>
 <div id="file-list">
   <span *ngFor="let file of fileStorageService.images" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -12,10 +12,10 @@
 </label>
 <hr/>
 <div id="search">
-  検索：  <input [(ngModel)]="searchWord"  placeholder="部分一致で検索" /> 
+  検索：  <input [(ngModel)]="searchWd"  placeholder="部分一致で検索" />  <button (click)="searchImageFromTag()">検索</button>
 </div>
 <div id="edit-tag">
-  選択した画像のタグ：  <input [(ngModel)]="selectedImageTag"  placeholder="" /> 
+  選択した画像のタグ：  <input [(ngModel)]="selectedIT"  placeholder="" /> <button (click)="changeTag()">変更</button>
 </div>
 <hr/>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -14,6 +14,8 @@ import { PanelService } from 'service/panel.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
+  private searchWord:string = 'default';
+  private selectedImageTag:string = '';
 
   fileStorageService = ImageStorage.instance;
   constructor(

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -17,6 +17,12 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   private searchWord:string = 'default';
   private selectedImageTag:string = '';
 
+  //以下のget・setは暫定
+  get searchWd(): string { return this.searchWord; }
+  set searchWd(word:string) {this.searchWord = word; }
+　get selectedIT(): string{ return this.selectedImageTag; }
+  set selectedIT(word:string) {this.selectedImageTag = word; }
+
   fileStorageService = ImageStorage.instance;
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -47,5 +53,13 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   onSelectedFile(file: ImageFile) {
     console.log('onSelectedFile', file);
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
+  }
+
+  searchImageFromTag() {
+    console.log('検索ボタン押下/検索ワード：' + this.searchWord );
+  }
+
+  changeTag() {
+    console.log('検索ボタン押下/変更後タグ：' + this.selectedImageTag );
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -3,6 +3,7 @@ import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, O
 import { FileArchiver } from '@udonarium/core/file-storage/file-archiver';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
+import { ImageTagList } from '@udonarium/image-tag-list';
 import { EventSystem, Network } from '@udonarium/core/system';
 
 import { PanelService } from 'service/panel.service';
@@ -48,6 +49,8 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   onSelectedFile(file: ImageFile) {
     console.log('onSelectedFile', file);
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
+
+    this.selectedImageTag = ImageTagList.instance.getTagFromIdentifier(file.identifier).tag;
   }
 
   searchImageFromTag() {

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -14,14 +14,9 @@ import { PanelService } from 'service/panel.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
-  private searchWord:string = 'default';
-  private selectedImageTag:string = '';
-
-  //以下のget・setは暫定
-  get searchWd(): string { return this.searchWord; }
-  set searchWd(word:string) {this.searchWord = word; }
-　get selectedIT(): string{ return this.selectedImageTag; }
-  set selectedIT(word:string) {this.selectedImageTag = word; }
+  searchWord:string = 'default';
+  selectedImageTag:string = '';
+  isTagTextBoxChanged:boolean = false;
 
   fileStorageService = ImageStorage.instance;
   constructor(
@@ -60,6 +55,10 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   changeTag() {
-    console.log('検索ボタン押下/変更後タグ：' + this.selectedImageTag );
+    console.log('変更ボタン押下/変更後タグ：' + this.selectedImageTag );
+  }
+
+  changeTagTextBox() {
+    this.isTagTextBoxChanged = true;
   }
 }

--- a/src/app/service/save-data.service.ts
+++ b/src/app/service/save-data.service.ts
@@ -76,4 +76,7 @@ export class SaveDataService {
     }
     return files;
   }
+
+  //NktAts-20190716：ここに、以下のメソッドを足す
+  //イメージタグとXMLを引数として、存在するイメージタグの保存フラグをtrueにするメソッド
 }

--- a/src/app/service/tabletop.service.ts
+++ b/src/app/service/tabletop.service.ts
@@ -19,6 +19,7 @@ import { TextNote } from '@udonarium/text-note';
 
 import { ContextMenuAction } from './context-menu.service';
 import { PointerCoordinate, PointerDeviceService } from './pointer-device.service';
+import { ImageTagList } from '@udonarium/image-tag-list';
 
 type ObjectIdentifier = string;
 type LocationName = string;
@@ -236,7 +237,10 @@ export class TabletopService {
   createTerrain(position: PointerCoordinate): Terrain {
     let url: string = './assets/images/tex.jpg';
     let image: ImageFile = ImageStorage.instance.get(url)
-    if (!image) image = ImageStorage.instance.add(url);
+    if (!image) {
+      image = ImageStorage.instance.add(url);
+      ImageTagList.instance.pushTag(image.identifier,'default , 地形');
+    }
 
     let viewTable = this.tableSelecter.viewTable;
     if (!viewTable) return;
@@ -265,7 +269,10 @@ export class TabletopService {
     diceSymbol.faces.forEach(face => {
       let url: string = `./assets/images/dice/${imagePathPrefix}/${imagePathPrefix}[${face}].png`;
       image = ImageStorage.instance.get(url)
-      if (!image) { image = ImageStorage.instance.add(url); }
+      if (!image) { 
+        image = ImageStorage.instance.add(url); 
+        ImageTagList.instance.pushTag(image.identifier,'default , ダイス');
+      }
       diceSymbol.imageDataElement.getFirstElementByName(face).value = image.identifier;
     });
 
@@ -283,7 +290,8 @@ export class TabletopService {
 
     let back: string = './assets/images/trump/z02.gif';
     if (!ImageStorage.instance.get(back)) {
-      ImageStorage.instance.add(back);
+      let newImage = ImageStorage.instance.add(back);
+      ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
     }
 
     let names: string[] = ['c', 'd', 'h', 's'];
@@ -293,7 +301,8 @@ export class TabletopService {
         let trump: string = name + (('00' + i).slice(-2));
         let url: string = './assets/images/trump/' + trump + '.gif';
         if (!ImageStorage.instance.get(url)) {
-          ImageStorage.instance.add(url);
+          let newImage = ImageStorage.instance.add(url);
+          ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
         }
         let card = Card.create('カード', url, back);
         cardStack.putOnBottom(card);
@@ -304,7 +313,8 @@ export class TabletopService {
       let trump: string = 'x' + (('00' + i).slice(-2));
       let url: string = './assets/images/trump/' + trump + '.gif';
       if (!ImageStorage.instance.get(url)) {
-        ImageStorage.instance.add(url);
+        let newImage = ImageStorage.instance.add(url);
+        ImageTagList.instance.pushTag(newImage.identifier,'default , トランプ');
       }
       let card = Card.create('カード', url, back);
       cardStack.putOnBottom(card);
@@ -321,10 +331,12 @@ export class TabletopService {
     let bgFileContext = ImageFile.createEmpty('testTableBackgroundImage_image').toContext();
     bgFileContext.url = './assets/images/BG10a_80.jpg';
     testBgFile = ImageStorage.instance.add(bgFileContext);
+    ImageTagList.instance.pushTag(testBgFile.identifier,'default , テーブル')
     //let testDistanceFile: ImageFile = null;
     //let distanceFileContext = ImageFile.createEmpty('testTableDistanceviewImage_image').toContext();
     //distanceFileContext.url = './assets/images/BG00a1_80.jpg';
     //testDistanceFile = ImageStorage.instance.add(distanceFileContext);
+    //ImageTagList.instance.pushTag(testDistanceFile.identifier,'default , テーブル')
     gameTable.name = '最初のテーブル';
     gameTable.imageIdentifier = testBgFile.identifier;
     //gameTable.backgroundImageIdentifier = testDistanceFile.identifier;
@@ -344,6 +356,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_1_image').toContext();
     fileContext.url = './assets/images/mon_052.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 9 * 50;
     testCharacter.initialize();
@@ -359,6 +372,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_3_image').toContext();
     fileContext.url = './assets/images/mon_128.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 4 * 50;
     testCharacter.location.y = 2 * 50;
     testCharacter.initialize();
@@ -368,6 +382,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_4_image').toContext();
     fileContext.url = './assets/images/mon_150.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 6 * 50;
     testCharacter.location.y = 11 * 50;
     testCharacter.initialize();
@@ -377,6 +392,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_5_image').toContext();
     fileContext.url = './assets/images/mon_211.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.location.x = 12 * 50;
     testCharacter.location.y = 12 * 50;
     testCharacter.initialize();
@@ -386,6 +402,7 @@ export class TabletopService {
     fileContext = ImageFile.createEmpty('testCharacter_6_image').toContext();
     fileContext.url = './assets/images/mon_135.gif';
     testFile = ImageStorage.instance.add(fileContext);
+    ImageTagList.instance.pushTag(testFile.identifier,'default , キャラクター');
     testCharacter.initialize();
     testCharacter.location.x = 5 * 50;
     testCharacter.location.y = 13 * 50;


### PR DESCRIPTION
# 概要
Issue #56 にて要望されているうち、以下の機能を追加します。

- 「画像」メニューで開く画像一覧画面から、タグを付与・変更することができる機能とタグ検索する機能を追加
- 各種オブジェクトの画像変更画面にタグ検索する機能を追加


# ユーザに見える仕様

1. 「画像」メニューで開く画像一覧画面に、以下を追加

-  「検索」欄（テキスト、テキストボックス、「検索」ボタン）
- 「選択した画像のタグ」欄（テキスト、テキストボックス、「変更」ボタン）　※ テキストボックスに変更があったときだけ「変更」ボタンを操作可能にする

2. 各種オブジェクトの画像変更画面に以下を追加

- 「検索」テキストボックス

3. 各画像に、新規情報「タグ」を追加。仕様は以下の通り。

- 画像や、画像のついたオブジェクトを追加した時は、「画像を追加したプレイヤーのニックネーム」を設定（可否検討中）
- １つだけ（,などのセパレータで区切れば、実運用上は複数指定可能）
- 改行不可（改行コードは除去）

4. 「画像」メニューにて、画像を選択する機能を追加。選択した画像のタグを、「選択した画像のタグ」テキストボックスに表示する。

5. 「選択した画像のタグ」欄のテキストボックスにて、変更後のタグを入力しEnter入力 or「変更」ボタンを押下すると、画像のタグを変更。タグ更新を他プレイヤーに送信する。

6. 「検索」欄のテキストボックスに検索ワードを入力しEnter入力 or 「検索」ボタンを押下すると、検索ワードの部分一致にて画像タグを検索し、該当するものだけを画像一覧に表示する。

7. ルームデータを「保存」した場合、付与したタグも保存される。旧ルームデータを読み込んだ時、画像のタグは一律「default」を設定（キャラクターや地形などのオブジェクトにタグは保存しない想定）


# 必要な改修と進捗

（済） 画像一覧画面と画像選択画面に必要なUIを追加
（未） テキストボックスに変更があったときだけ「変更」ボタンを操作可能にするUI仕様追加
（未） タグ情報のプロパティを追加（保持方法検討中）
（未） 新規画像追加時に、「画像を追加したプレイヤーのニックネーム」を付与する機能追加
（未） 画像一覧画面に、画像を選択する機能と、選択したときに画像に対応するタグを表示する機能を追加
（未） 画像一覧画面から入力されたときに、タグを変更する機能を追加
（未） 画像追加時・タグ変更時にタグを他プレイヤーに送信する機能追加
（未） 画像一覧画面と画像選択画面に、タグで検索ワードの部分一致によって画像を検索する機能と、画像一覧を更新する機能を追加
（未） ルームデータにタグを保存する機能追加
（未） ルームデータを読み込んだ時、各画像のタグを読み込む機能を追加


# 検討中の事項・仕様の懸念点など

- もし可能なら、検索欄からは「検索」ボタンをなくし、随時画像一覧に検索結果が反映されるようにしたい

# UIイメージ

![タグ検索1](https://user-images.githubusercontent.com/48486798/61222791-5cf38500-a756-11e9-969f-beb9d5f80558.jpg)
![タグ検索2](https://user-images.githubusercontent.com/48486798/61222792-5d8c1b80-a756-11e9-900a-f9d6bd9328f8.jpg)
