### PR TITLE
ダイス操作ログの記録機能

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -87,6 +87,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
 
     let chatTab: ChatTab = new ChatTab('MainTab');
     chatTab.name = 'メインタブ';
+    chatTab.receiveInfo = true;
     chatTab.initialize();
 
     chatTab = new ChatTab('SubTab');

--- a/src/app/class/chat-tab.ts
+++ b/src/app/class/chat-tab.ts
@@ -18,6 +18,8 @@ export class ChatTab extends ObjectNode implements InnerXml {
     return lastIndex < 0 ? 0 : this.chatMessages[lastIndex].timestamp;
   }
 
+  @SyncVar() receiveInfo = false;
+
   // ObjectNode Lifecycle
   onChildAdded(child: ObjectNode) {
     super.onChildAdded(child);

--- a/src/app/component/chat-message/chat-message.component.css
+++ b/src/app/component/chat-message/chat-message.component.css
@@ -58,14 +58,14 @@
   white-space: pre-wrap;
 }
 
-.dicebot-message .msg-name {
+.system-message .msg-name {
   font-size: 8px;
 }
 
-.dicebot-message .msg-text {
+.system-message .msg-text {
   /*color:#22F;*/
 }
 
-.direct-message.dicebot-message .msg-text {
+.direct-message.system-message .msg-text {
   /*color:#CCF;*/
 }

--- a/src/app/component/chat-palette/chat-palette.component.css
+++ b/src/app/component/chat-palette/chat-palette.component.css
@@ -108,3 +108,8 @@
   top: -4px;
   right: 0;
 }
+
+.material-icons {
+  vertical-align: middle;
+  font-size: 1rem;
+}

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -4,7 +4,7 @@
       <div class="chat-tab">
         <label *ngFor="let chatTab of chatMessageService.chatTabs">
           <input name="chat-tab" type="radio" value="{{chatTab.identifier}}" ng-control="options" [(ngModel)]="chatTabidentifier">
-          <div>{{chatTab.name}}<badge *ngIf="chatTab.hasUnread" class="badge" [count]="chatTab.unreadLength"></badge></div>
+          <div>{{chatTab.name}}<i *ngIf="chatTab.receiveInfo" class="material-icons">info</i><badge *ngIf="chatTab.hasUnread" class="badge" [count]="chatTab.unreadLength"></badge></div>
         </label>
       </div>
     </form>

--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.html
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.html
@@ -15,6 +15,11 @@
       <hr/>
       <div>
         <ng-container *ngIf="!isDeleted">
+          <label>
+            操作ログを受け取る
+            <input type="checkbox" [(ngModel)]="receiveInfo" />
+          </label>
+          <br />
           <button (click)="save()">保存</button>
           <button class="danger" (click)="delete()" [attr.disabled]="chatTabs.length <= 1 ? '' : null">削除</button>
         </ng-container>

--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
@@ -27,6 +27,9 @@ export class ChatTabSettingComponent implements OnInit, OnDestroy {
   get isDeleted(): boolean { return this.selectedTab ? ObjectStore.instance.get(this.selectedTab.identifier) == null : false; }
   get isEditable(): boolean { return !this.isEmpty && !this.isDeleted; }
 
+  get receiveInfo(): boolean { return this.selectedTab.receiveInfo; }
+  set receiveInfo(receiveInfo: boolean) { this.selectedTab.receiveInfo = receiveInfo; }
+
   constructor(
     private modalService: ModalService,
     private panelService: PanelService,

--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
@@ -28,7 +28,9 @@ export class ChatTabSettingComponent implements OnInit, OnDestroy {
   get isEditable(): boolean { return !this.isEmpty && !this.isDeleted; }
 
   get receiveInfo(): boolean { return this.selectedTab.receiveInfo; }
-  set receiveInfo(receiveInfo: boolean) { this.selectedTab.receiveInfo = receiveInfo; }
+  set receiveInfo(receiveInfo: boolean) {
+    this.chatMessageService.setReceiveInfo(this.selectedTab, receiveInfo);
+  }
 
   constructor(
     private modalService: ModalService,

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -9,7 +9,7 @@
     <div class="chat-tab">
       <label *ngFor="let chatTab of chatMessageService.chatTabs; trackBy: trackByChatTab">
         <input name="chat-tab" type="radio" value="{{chatTab.identifier}}" ng-control="options" [(ngModel)]="chatTabidentifier">
-        <div>{{chatTab.name}}<badge *ngIf="chatTab.hasUnread" class="badge" [count]="chatTab.unreadLength"></badge></div>
+        <div>{{chatTab.name}}<i *ngIf="chatTab.receiveInfo" class="material-icons">info</i><badge *ngIf="chatTab.hasUnread" class="badge" [count]="chatTab.unreadLength"></badge></div>
       </label>
       <button class="tab-setting small-font" (click)="showTabSetting()"><i class="material-icons small-font">settings</i>タブ設定</button>
     </div>

--- a/src/app/component/dice-symbol/dice-symbol.component.ts
+++ b/src/app/component/dice-symbol/dice-symbol.component.ts
@@ -199,9 +199,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
         name: 'ダイスを公開', action: () => {
           this.owner = '';
           SoundEffect.play(PresetSound.unlock);
-          this.sendLogMessage(
-            `ダイス「${this.name}」を公開しました。出目:${this.face}`
-          );
+          this.sendLogMessage(`ダイスを公開しました。出目:${this.face}`);
         }
       });
     }
@@ -222,7 +220,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
             const prev = this.face;
             this.face = face;
             SoundEffect.play(PresetSound.dicePut);
-            let message = `ダイス「${this.name}」のダイス目を変更しました。`;
+            let message = `ダイス目を変更しました。`;
             if (!this.hasOwner) {
               message += `出目:${prev}→${face}`;
             }
@@ -267,7 +265,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
     SoundEffect.play(PresetSound.diceRoll1);
     const prev = this.face;
     const result = this.diceSymbol.diceRoll();
-    let message = `ダイス「${this.name}」を振りました。`;
+    let message = `ダイスを振りました。`;
     if (!this.hasOwner) {
       message += `出目:${prev}→${result}`;
     }
@@ -299,16 +297,7 @@ export class DiceSymbolComponent implements OnInit, OnDestroy {
   }
 
   private sendLogMessage(text: string): void {
-    const infoTab = this.chatMessageService.infoTab;
-    if (!infoTab) {
-      return;
-    }
-    this.chatMessageService.sendMessage(
-      infoTab,
-      text,
-      '',
-      PeerCursor.myCursor.identifier,
-      ''
-    );
+    const name = `<${this.name}：${PeerCursor.myCursor.name}>`;
+    this.chatMessageService.sendSystemMessage(name, text, 'DiceSymbol');
   }
 }

--- a/src/app/service/chat-message.service.ts
+++ b/src/app/service/chat-message.service.ts
@@ -32,6 +32,12 @@ export class ChatMessageService {
   get infoTab(): ChatTab {
     return this.chatTabs.find(chatTab => chatTab.receiveInfo);
   }
+  setReceiveInfo(chatTab: ChatTab, receiveInfo: boolean): void {
+    this.chatTabs
+      .filter(tab => tab.receiveInfo)
+      .forEach(tab => (tab.receiveInfo = false));
+    chatTab.receiveInfo = receiveInfo;
+  }
 
   calibrateTimeOffset() {
     if (this.intervalTimer != null) {

--- a/src/app/service/chat-message.service.ts
+++ b/src/app/service/chat-message.service.ts
@@ -29,6 +29,10 @@ export class ChatMessageService {
     return ObjectStore.instance.getObjects(ChatTab);
   }
 
+  get infoTab(): ChatTab {
+    return this.chatTabs.find(chatTab => chatTab.receiveInfo);
+  }
+
   calibrateTimeOffset() {
     if (this.intervalTimer != null) {
       console.log('calibrateTimeOffset was canceled.');

--- a/src/app/service/chat-message.service.ts
+++ b/src/app/service/chat-message.service.ts
@@ -91,6 +91,24 @@ export class ChatMessageService {
     return chatTab.addMessage(chatMessage);
   }
 
+  sendSystemMessage(name: string, text: string, type?: string): void {
+    if (!this.infoTab) {
+      return;
+    }
+    const systemMessage: ChatMessageContext = {
+      identifier: '',
+      tabIdentifier: this.infoTab.identifier,
+      originFrom: Network.peerContext.id,
+      from: type ? `System-${type}` : 'System',
+      timestamp: this.calcTimeStamp(this.infoTab),
+      imageIdentifier: '',
+      tag: 'system',
+      name,
+      text
+    };
+    this.infoTab.addMessage(systemMessage);
+  }
+
   private findId(identifier: string): string {
     let object = ObjectStore.instance.get(identifier);
     if (object instanceof GameCharacter) {


### PR DESCRIPTION
# 概要

ダイスの操作をした場合にシステムメッセージを送る機能です。

#67 で挙げられている
> 2ダイス目を変更した際に「PLがダイス目を変更しました」というコメントをメイン等でだすシステム。
> ダイス目公開の公平さを保つことと（悪用防止）、ＧＭが確認する際に重宝します。

の内容の機能をカバーしています。

テスト環境: http://yoshis-island.net/udondev/
![image](https://user-images.githubusercontent.com/7685946/62867078-5a804d00-bd4d-11e9-83fa-bb3867560a93.png)


# 詳細

このPRには主に2つの大きな変更が含まれています。
（PRを分割したほうがよければ分割します。）

1. チャットタブのひとつを操作ログを受け付けるタブにする
1. ダイス操作の際に、上で設定した操作ログタブにシステムメッセージを送る


## チャットタブのひとつを操作ログを受け付けるタブにする
### 方針
#36 で検討されていた「操作ログ記録用のタブ」を元に実装しましたが、
以下の2点をこちらで変更して実装しています。
- 「操作ログ記録用のタブ」を自由に選べるように（ただし、設定できるのは1つのみ）
- 「操作ログ記録用のタブ」は無くてもよい

上記の変更を加えた理由は、
1. 操作ログをセッション進行を行うメインのチャットに流したい人
1. 操作ログをメインのチャットとは別のチャットに流したい人
1. 操作ログを表示したくない人

などが考えられるからです。

### 実装
`ChatTab`に操作ログを受け付けるフラグ`receiveInfo`を持たせて、
`receiveInfo`が`true`となっているタブへシステムメッセージを飛ばすように
`ChatMessageService`に関数を追加しています。


## ダイス操作の際に、上で設定した操作ログタブにシステムメッセージを送る
どどんとふに倣って、「ダイスを振る」「ダイス目の変更」「ダイスの公開」時に
システムメッセージを送るようにしました。
また、ダイスが公開されているときには、出目の変更履歴もメッセージに記すようにしていますが、
非公開時にはそれを抑制しています。


# 備考
操作ログ周りの機能がこのPRの内容で構わなければ、
カードの操作ログもPRを出そうと考えています。

ご査収ください。
