### PR TITLE
Feat: キャラクターをコピーしたときに番号を付与する

### DIFF
--- a/src/app/class/game-character.ts
+++ b/src/app/class/game-character.ts
@@ -18,6 +18,8 @@ export class GameCharacter extends TabletopObject {
     return null;
   }
 
+  set name(value:string) { this.setCommonValue('name', value); }
+
   static create(name: string, size: number, imageIdentifier: string): GameCharacter {
     let gameCharacter: GameCharacter = new GameCharacter();
     gameCharacter.createDataElements();

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -22,6 +22,7 @@ import { RotableOption } from 'directive/rotable.directive';
 import { ContextMenuSeparator, ContextMenuService } from 'service/context-menu.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { debug } from 'util';
 
 @Component({
   selector: 'game-character',
@@ -152,6 +153,9 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
       {
         name: 'コピーを作る', action: () => {
           let cloneObject = this.gameCharacter.clone();
+
+          cloneObject.name = this.appendCloneNumber(cloneObject.name);
+
           cloneObject.location.x += this.gridSize;
           cloneObject.location.y += this.gridSize;
           cloneObject.update();
@@ -187,5 +191,18 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
     let option: PanelOption = { left: coordinate.x - 250, top: coordinate.y - 175, width: 615, height: 350 };
     let component = this.panelService.open<ChatPaletteComponent>(ChatPaletteComponent, option);
     component.character = gameObject;
+  }
+
+  private appendCloneNumber(objectname: string): string {    
+    let reg = new RegExp('(.*)_([0-9]*)');
+    let res = objectname.match(reg);
+    console.log(res);
+
+    if(res != null && res.length == 3) {
+      let cloneNumber:number = parseInt(res[2]) + 1;
+      return res[1] + "_" + cloneNumber;
+    } else {
+      return objectname + "_2";
+    }
   }
 }

--- a/src/app/component/game-character/game-character.component.ts
+++ b/src/app/component/game-character/game-character.component.ts
@@ -22,7 +22,6 @@ import { RotableOption } from 'directive/rotable.directive';
 import { ContextMenuSeparator, ContextMenuService } from 'service/context-menu.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
-import { debug } from 'util';
 
 @Component({
   selector: 'game-character',
@@ -196,7 +195,6 @@ export class GameCharacterComponent implements OnInit, OnDestroy, AfterViewInit 
   private appendCloneNumber(objectname: string): string {    
     let reg = new RegExp('(.*)_([0-9]*)');
     let res = objectname.match(reg);
-    console.log(res);
 
     if(res != null && res.length == 3) {
       let cloneNumber:number = parseInt(res[2]) + 1;


### PR DESCRIPTION
【概要】
　現在の仕様だと、単純にコマをコピーしたときすべて同じ名前になってしまい、見分けがつかなくなってしまうので、番号を付与するよう仕様を追加しました。

【詳細】
1. キャラクターのnameが「*_n」(nは1つ以上の半角数字)の場合、名前を「*_(n+1)」に変更してコピー
1. ↑以外の場合、名前を「*_2」に変更してコピー

【懸念点】
　処理を単純化するため、「同じ名前のキャラクターコマがあるかどうか」はチェックしていません。
　そのため、順番にナンバリングするためには、

1. ベースのキャラクターコマをコピー
1. 新たにできた「*_2」をコピー
1.  新たにできた「*_3」をコピー
（以下同様）

　という形でコピーを行う必要があります。