### PR TITLE
効果音音量とBGM音量の分割

### DIFF
--- a/src/app/class/core/file-storage/audio-player.ts
+++ b/src/app/class/core/file-storage/audio-player.ts
@@ -4,6 +4,7 @@ import { FileReaderUtil } from './file-reader-util';
 export enum VolumeType {
   MASTER,
   AUDITION,
+  SOUND_EFFECT
 }
 
 export class AudioPlayer {
@@ -27,10 +28,17 @@ export class AudioPlayer {
     AudioPlayer.auditionGainNode.gain.setTargetAtTime(AudioPlayer._auditionVolume, AudioPlayer.audioContext.currentTime, 0.01);
   }
 
+  private static _sfxVolume: number = 0.5;
+  static get sfxVolume(): number { return AudioPlayer._sfxVolume }
+  static set sfxVolume(sfxVolume: number) {
+    AudioPlayer._sfxVolume = sfxVolume;
+    AudioPlayer.sfxGainNode.gain.setTargetAtTime(AudioPlayer._sfxVolume, AudioPlayer.audioContext.currentTime, 0.01);
+  }
+
   private static _masterGainNode: GainNode
   private static get masterGainNode(): GainNode {
     if (!AudioPlayer._masterGainNode) {
-      let masterGain = AudioPlayer.audioContext.createGain();
+      const masterGain = AudioPlayer.audioContext.createGain();
       masterGain.gain.setValueAtTime(AudioPlayer._volume, AudioPlayer.audioContext.currentTime);
       masterGain.connect(AudioPlayer.audioContext.destination);
       AudioPlayer._masterGainNode = masterGain;
@@ -41,7 +49,7 @@ export class AudioPlayer {
   private static _auditionGainNode: GainNode
   private static get auditionGainNode(): GainNode {
     if (!AudioPlayer._auditionGainNode) {
-      let auditionGain = AudioPlayer.audioContext.createGain();
+      const auditionGain = AudioPlayer.audioContext.createGain();
       auditionGain.gain.setValueAtTime(AudioPlayer._auditionVolume, AudioPlayer.audioContext.currentTime);
       auditionGain.connect(AudioPlayer.audioContext.destination);
       AudioPlayer._auditionGainNode = auditionGain;
@@ -49,8 +57,20 @@ export class AudioPlayer {
     return AudioPlayer._auditionGainNode;
   }
 
+  private static _sfxGainNode: GainNode
+  private static get sfxGainNode(): GainNode {
+    if(!AudioPlayer._sfxGainNode){
+      const sfxGain = AudioPlayer.audioContext.createGain();
+      sfxGain.gain.setValueAtTime(AudioPlayer._sfxVolume, AudioPlayer.audioContext.currentTime);
+      sfxGain.connect(AudioPlayer.audioContext.destination);
+      AudioPlayer._sfxGainNode = sfxGain;
+    }
+    return AudioPlayer._sfxGainNode;
+  }
+
   static get rootNode(): AudioNode { return AudioPlayer.masterGainNode; }
   static get auditionNode(): AudioNode { return AudioPlayer.auditionGainNode; }
+  static get sfxNode(): AudioNode{ return AudioPlayer.sfxGainNode;}
 
   private _audioElm: HTMLAudioElement;
   private get audioElm(): HTMLAudioElement {
@@ -134,6 +154,8 @@ export class AudioPlayer {
     switch (this.volumeType) {
       case VolumeType.AUDITION:
         return AudioPlayer.auditionNode;
+      case VolumeType.SOUND_EFFECT:
+        return AudioPlayer.sfxNode;
       default:
         return AudioPlayer.rootNode;
     }

--- a/src/app/class/sound-effect.ts
+++ b/src/app/class/sound-effect.ts
@@ -1,6 +1,6 @@
 import { ChatMessage, ChatMessageContext } from './chat-message';
 import { AudioFile } from './core/file-storage/audio-file';
-import { AudioPlayer } from './core/file-storage/audio-player';
+import { AudioPlayer, VolumeType } from './core/file-storage/audio-player';
 import { AudioStorage } from './core/file-storage/audio-storage';
 import { SyncObject } from './core/synchronize-object/decorator';
 import { GameObject } from './core/synchronize-object/game-object';
@@ -27,12 +27,14 @@ export class PresetSound {
 
 @SyncObject('sound-effect')
 export class SoundEffect extends GameObject {
+  readonly sfxPlayer: AudioPlayer = new AudioPlayer();
   // GameObject Lifecycle
   onStoreAdded() {
     super.onStoreAdded();
+    this.sfxPlayer.volumeType = VolumeType.SOUND_EFFECT;
     EventSystem.register(this)
       .on<string>('SOUND_EFFECT', event => {
-        AudioPlayer.play(AudioStorage.instance.get(event.data), 0.5);
+        this.sfxPlayer.play(AudioStorage.instance.get(event.data));
       })
       .on('SEND_MESSAGE', event => {
         let chatMessage = ObjectStore.instance.get<ChatMessage>(event.data.messageIdentifier);

--- a/src/app/component/jukebox/jukebox.component.css
+++ b/src/app/component/jukebox/jukebox.component.css
@@ -21,3 +21,17 @@
 .box {
   border-bottom:1px dotted #888;
 }
+
+.volume-wrapper {
+  display: flex;
+  justify-content: space-between;
+  height: 24px;
+}
+
+.volume-label {
+  min-width: 128px;
+}
+
+.volume-controller {
+  width: 100%;
+}

--- a/src/app/component/jukebox/jukebox.component.html
+++ b/src/app/component/jukebox/jukebox.component.html
@@ -1,5 +1,6 @@
-<div>試聴音量：<input [(ngModel)]="auditionVolume" type="range" min="0" max="1" step="0.01" /></div>
-<div>BGM音量：<input [(ngModel)]="volume" type="range" min="0" max="1" step="0.01" /></div>
+<div class="volume-wrapper"><div class="volume-label">試聴音量：</div><input class="volume-controller" [(ngModel)]="auditionVolume" type="range" min="0" max="1" step="0.01" /></div>
+<div class="volume-wrapper"><div class="volume-label">BGM音量：</div><input class="volume-controller" [(ngModel)]="volume" type="range" min="0" max="1" step="0.01" /></div>
+<div class="volume-wrapper"><div class="volume-label">効果音音量：</div><input class="volume-controller" [(ngModel)]="sfxVolume" type="range" min="0" max="1" step="0.01" /></div>
 <hr/>
 <div>
   <div *ngFor="let audio of audios" class="box">

--- a/src/app/component/jukebox/jukebox.component.ts
+++ b/src/app/component/jukebox/jukebox.component.ts
@@ -24,6 +24,9 @@ export class JukeboxComponent implements OnInit, OnDestroy {
   get auditionVolume(): number { return AudioPlayer.auditionVolume; }
   set auditionVolume(auditionVolume: number) { AudioPlayer.auditionVolume = auditionVolume; }
 
+  get sfxVolume(): number { return AudioPlayer.sfxVolume; }
+  set sfxVolume(sfxVolume: number) { AudioPlayer.sfxVolume = sfxVolume; }
+
   get audios(): AudioFile[] { return AudioStorage.instance.audios.filter(audio => !audio.isHidden); }
   get jukebox(): Jukebox { return ObjectStore.instance.get<Jukebox>('Jukebox'); }
 


### PR DESCRIPTION
## 概要
現状の音量設定は視聴用とBGM用（マスター音量）の二種類になっており、BGMを下げた時に効果音が聞こえづらくなってしまいます。
上記によりダイスロール時の音がBGMにかき消されてしまったり、効果音に合わせて音量を下げるとBGMが小さくなりすぎてしまったりと取り回しがよくないと感じました。
そこで、nodeをひとつ追加し効果音に対して別の音量を設定できるようにします。

## 修正点
- AudioPlayerに新規nodeを追加し効果音に別音量を設定できるようにしました
- Jukeboxのコンポーネントに効果音を調整するスライダーを追加しました

## 懸念点
- 単純にnodeを一つ追加しただけなのですが、同じようなコードが３つ並んでしまっているのでおそらく書き方的によくないのではないかと感じています（ただ技術的にどう解決するのがベストかわからなかったためこのような実装にしました)
- UI的にJukeboxにスライダーを並べるのがよくない気がしています（他に配置する場所がなかったので暫定的にこちらに置いています）

## その他
大した修正ではないのですが、せっかく実装された効果音機能を十分に楽しめないのは残念だなと思いPRを送らせていただきました。
他機能実装との兼ね合い等あればリジェクトしていただいて構いません、検討よろしくお願いいたします。