### PR TITLE
feat: タブ設定に「全タブのメッセージを消去」を追加

### DIFF
--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.html
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.html
@@ -25,6 +25,9 @@
     </ng-container>
   </div>
 </div>
+<div>
+    <button class="danger" (click)="allMessageClear()" [attr.disabled]="chatTabs.length <= 1 ? '' : null">全タブのメッセージを消去</button>
+</div>
 <ng-container *ngIf="isEmpty">
   <div style="font-size: 12px;">※チャットタブが１つも作成されていません。「チャットタブを作る」からチャットタブを作成することができます。</div>
 </ng-container>

--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
@@ -75,6 +75,18 @@ export class ChatTabSettingComponent implements OnInit, OnDestroy {
     }
   }
 
+  allMessageClear() {
+    this.chatTabs.map(function(nowTab) {
+      let chatTab = new ChatTab();
+      chatTab.name = nowTab.name;
+      
+      nowTab.destroy();
+      chatTab.initialize();
+    });
+
+    this.selectedTab = null;
+  }
+
   restore() {
     if (this.selectedTab && this.selectedTabXml) {
       let restoreTable = ObjectSerializer.instance.parseXml(this.selectedTabXml);


### PR DESCRIPTION
## 概要
　タブ設定画面の最下部に、「全タブのメッセージを消去」ボタンを追加しました。
　押下すると、タブの項目はそのままに、すべてのメッセージを消去します。

## 更新理由
　多人数で１つのルームにログイン、かつメッセージの数が大量になった場合（確認した範囲では６人以上かつ全メッセージ5000以上）、ログインが行えなくなる事象を確認しました。
　chat.xmlをいじる、全タブ消去ののち作り直すなどは手間だったため、メッセージ消去ボタンを追加しました。

## 実装詳細
　実装上は、「各タブを一度destroy」→「同じ名称で再度生成」という形で実装しています。