### PR TITLE
非公開画像の設定

### DIFF
--- a/src/app/class/core/file-storage/image-file.ts
+++ b/src/app/class/core/file-storage/image-file.ts
@@ -10,6 +10,7 @@ export enum ImageState {
 export interface ImageContext {
   identifier: string;
   name: string;
+  owner: string;
   type: string;
   blob: Blob;
   url: string;
@@ -26,6 +27,7 @@ export class ImageFile {
   private context: ImageContext = {
     identifier: '',
     name: '',
+    owner: '',
     blob: null,
     type: '',
     url: '',
@@ -38,6 +40,8 @@ export class ImageFile {
 
   get identifier(): string { return this.context.identifier };
   get name(): string { return this.context.name };
+  get owner(): string { return this.context.owner };
+  set owner(owner: string) { this.context.owner = owner };
   get blob(): Blob { return this.context.blob ? this.context.blob : this.context.thumbnail.blob; };
   get url(): string { return this.context.url ? this.context.url : this.context.thumbnail.url; };
   get thumbnail(): ThumbnailContext { return this.context.thumbnail };
@@ -111,6 +115,7 @@ export class ImageFile {
   apply(context: ImageContext) {
     if (!this.context.identifier && context.identifier) this.context.identifier = context.identifier;
     if (!this.context.name && context.name) this.context.name = context.name;
+    if (!this.context.owner && context.owner) this.context.owner = context.owner;
     if (!this.context.blob && context.blob) this.context.blob = context.blob;
     if (!this.context.type && context.type) this.context.type = context.type;
     if (!this.context.url && context.url) {
@@ -130,6 +135,7 @@ export class ImageFile {
     return {
       identifier: this.context.identifier,
       name: this.context.name,
+      owner: this.context.owner,
       blob: this.context.blob,
       type: this.context.type,
       url: this.context.url,

--- a/src/app/class/core/file-storage/image-sharing-system.ts
+++ b/src/app/class/core/file-storage/image-sharing-system.ts
@@ -192,6 +192,7 @@ export class FileSharingSystem {
       let context: ImageContext = {
         identifier: image.identifier,
         name: image.name,
+        owner: image.owner,
         type: '',
         blob: null,
         url: null,

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -1,9 +1,11 @@
 import { EventSystem } from '../system';
 import { ImageContext, ImageFile, ImageState } from './image-file';
+import { Network } from '@udonarium/core/system';
 
 export type CatalogItem = { identifier: string, state: number };
 
 export class ImageStorage {
+  isPrivate: boolean = false;
   private static _instance: ImageStorage
   static get instance(): ImageStorage {
     if (!ImageStorage._instance) ImageStorage._instance = new ImageStorage();
@@ -16,6 +18,23 @@ export class ImageStorage {
     let images: ImageFile[] = [];
     for (let identifier in this.imageHash) {
       images.push(this.imageHash[identifier]);
+    }
+    return images;
+  }
+
+  get publicImages(): ImageFile[] {
+    let images: ImageFile[] = [];
+    for (let identifier in this.imageHash) {
+      let image: ImageFile = this.imageHash[identifier];
+      if (!image.owner) images.push(image);
+    }
+    return images;
+  }
+  get privateImages(): ImageFile[] {
+    let images: ImageFile[] = [];
+    for (let identifier in this.imageHash) {
+      let image: ImageFile = this.imageHash[identifier];
+      if (image.owner === Network.peerId) images.push(image);
     }
     return images;
   }
@@ -36,6 +55,7 @@ export class ImageStorage {
   async addAsync(blob: Blob): Promise<ImageFile>
   async addAsync(arg: any): Promise<ImageFile> {
     let image: ImageFile = await ImageFile.createAsync(arg);
+    if (this.isPrivate) image.owner = Network.peerId;
 
     return this._add(image);
   }

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,9 +1,18 @@
+<div id="private-images-checkbox">
+  <label>非公開画像:
+    <input type="checkbox" [(ngModel)]="isPrivate" name="isPrivate" />
+  </label>
+</div>
 <div id="file-list">
   <span class="empty" *ngIf="isAllowedEmpty">
     <button (click)="onSelectedFile(empty)">画像なし</button>
   </span>
-  <span *ngFor="let file of images" class="image">
+  <span *ngFor="let file of publicImages" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
+    <img *ngIf="file.url.length <= 0" src="./assets/images/loading.gif" alt="{{file.name}}">
+  </span>
+  <span *ngFor="let file of privateImages" class="image">
+    <img *ngIf="0 < file.url.length && isPrivate" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="./assets/images/loading.gif" alt="{{file.name}}">
   </span>
 </div>

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -22,7 +22,8 @@ import { PanelService } from 'service/panel.service';
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() isAllowedEmpty: boolean = false;
-  get images(): ImageFile[] { return ImageStorage.instance.images; }
+  get publicImages(): ImageFile[] { return ImageStorage.instance.publicImages; }
+  get privateImages(): ImageFile[] { return ImageStorage.instance.privateImages; }
   get empty(): ImageFile { return ImageFile.Empty; }
 
   constructor(

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -10,9 +10,18 @@
       <br>１ファイルにつき2MBまで</div>
   </div>
 </label>
+<div id="private-images-checkbox">
+  <label>非公開画像:
+    <input type="checkbox" [(ngModel)]="isPrivate" name="isPrivate" />
+  </label>
+</div>
 <div id="file-list">
-  <span *ngFor="let file of fileStorageService.images" class="image">
+  <span *ngFor="let file of fileStorageService.publicImages" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
+    <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
+  </span>
+  <span *ngFor="let file of fileStorageService.privateImages" class="image">
+    <img *ngIf="0 < file.url.length && isPrivate" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
   </span>
 </div>

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -21,6 +21,9 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     private panelService: PanelService
   ) { }
 
+  get isPrivate(): boolean { return this.fileStorageService.isPrivate; }
+  set isPrivate(isPrivate: boolean) { this.fileStorageService.isPrivate = isPrivate; }
+
   ngOnInit() {
     this.panelService.title = 'ファイル一覧';
   }


### PR DESCRIPTION
### 概要
ファイル一覧に非公開画像を追加できるようにしました．

### 目的
画像によるネタバレを恐れずに事前準備ができることを目的としています．

### 詳細
・ImageContextにowner属性を追加しました．
・ImageStorageにpublicImagesとprivateImagesを追加しました
・FileStorageComponentおよびFileSelecterComponentにisPrivateチェックボックスを追加しました
privateImagesはImageFileのownerと自身のpeerIdを比較して，一致したものとしています．
publicImagesはImageFileにownerが設定されていないものとしています．

### 実行画面
以下の画像を投稿した時の実行画面です
ユーザ0XWs6v：
　公開画像：丸
　非公開画像：四角
ユーザHpi3Mw：
　公開画像：三角
　非公開画像：五角
<img width="960" alt="証拠1" src="https://user-images.githubusercontent.com/26675666/71448064-5001a580-277a-11ea-9cc7-e89a128ac46d.png">

<img width="960" alt="証拠2" src="https://user-images.githubusercontent.com/26675666/71448066-54c65980-277a-11ea-911a-6f19f2bad252.png">

<img width="960" alt="証拠3" src="https://user-images.githubusercontent.com/26675666/71448075-6a3b8380-277a-11ea-80ad-26e968ad239a.png">

<img width="960" alt="証拠4" src="https://user-images.githubusercontent.com/26675666/71448078-6dcf0a80-277a-11ea-964e-fa37aaf525a9.png">

<img width="960" alt="証拠5" src="https://user-images.githubusercontent.com/26675666/71448079-70316480-277a-11ea-9801-56493f58e0b9.png">

### 問題点
#62 ではパスワードを設定することを想定していますが，この実装では公開と非公開の2択で設定しています．
ImageStorageにpublicImagesとprivateImagesを作成しましたが，よりよい実装があるような気がします．
publicImagesはImageFileにownerが設定されていないものとしましたが，この設定が真にpublicImagesと呼ぶべきものかは疑問が残ります．