### PR TITLE
Issues #56 画像へのタグ付与機能の追加

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,8 @@ import { FileArchiver } from '@udonarium/core/file-storage/file-archiver';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { FileSharingSystem } from '@udonarium/core/file-storage/image-sharing-system';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
+import { ImageTagStorage } from '@udonarium/core/file-storage/image-tag-storage';
+import { ImageTagSharingSystem } from '@udonarium/core/file-storage/image-tag-sharing-system';
 import { ObjectFactory } from '@udonarium/core/synchronize-object/object-factory';
 import { ObjectSerializer } from '@udonarium/core/synchronize-object/object-serializer';
 import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
@@ -64,6 +66,8 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       FileArchiver.instance.initialize();
       FileSharingSystem.instance.initialize();
       ImageStorage.instance;
+      ImageTagStorage.instance;
+      ImageTagSharingSystem.instance.initialize();
       AudioSharingSystem.instance.initialize();
       AudioStorage.instance;
       ObjectFactory.instance;
@@ -139,6 +143,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
       .on('DELETE_GAME_OBJECT', event => { this.lazyNgZoneUpdate(event.isSendFromSelf); })
       .on('SYNCHRONIZE_AUDIO_LIST', event => { if (event.isSendFromSelf) this.lazyNgZoneUpdate(false); })
       .on('SYNCHRONIZE_FILE_LIST', event => { if (event.isSendFromSelf) this.lazyNgZoneUpdate(false); })
+      .on('SYNCHRONIZE_IMAGETAG', event => { if (event.isSendFromSelf) this.lazyNgZoneUpdate(false); })
       .on<AppConfig>('LOAD_CONFIG', event => {
         console.log('LOAD_CONFIG !!!', event.data);
         Network.setApiKey(event.data.webrtc.key);

--- a/src/app/class/core/file-storage/file-archiver.ts
+++ b/src/app/class/core/file-storage/file-archiver.ts
@@ -6,6 +6,7 @@ import { XmlUtil } from '../system/util/xml-util';
 import { AudioStorage } from './audio-storage';
 import { FileReaderUtil } from './file-reader-util';
 import { ImageStorage } from './image-storage';
+import { ImageFile } from './image-file';
 import { ImageTagStorage } from './image-tag-storage';
 import { MimeType } from './mime-type';
 
@@ -88,7 +89,8 @@ export class FileArchiver {
     if (file.type.indexOf('image/') < 0) return;
     console.log(file.name + ' type:' + file.type);
     if (2 * 1024 * 1024 < file.size) return;
-    await ImageStorage.instance.addAsync(file);
+    let image: ImageFile = await ImageStorage.instance.addAsync(file);
+    await ImageTagStorage.instance.addAsync(image.identifier);
   }
 
   private async handleAudio(file: File) {

--- a/src/app/class/core/file-storage/file-archiver.ts
+++ b/src/app/class/core/file-storage/file-archiver.ts
@@ -6,6 +6,7 @@ import { XmlUtil } from '../system/util/xml-util';
 import { AudioStorage } from './audio-storage';
 import { FileReaderUtil } from './file-reader-util';
 import { ImageStorage } from './image-storage';
+import { ImageTagStorage } from './image-tag-storage';
 import { MimeType } from './mime-type';
 
 export class FileArchiver {
@@ -100,6 +101,10 @@ export class FileArchiver {
   private async handleText(file: File): Promise<void> {
     if (file.type.indexOf('text/') < 0) return;
     console.log(file.name + ' type:' + file.type);
+    if (file.type === 'text/csv') {
+      await ImageTagStorage.instance.loadAsync(file);
+      return;
+    }
     try {
       let xmlElement: Element = XmlUtil.xml2element(await FileReaderUtil.readAsTextAsync(file));
       if (xmlElement) EventSystem.trigger('XML_LOADED', { xmlElement: xmlElement });

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -1,6 +1,5 @@
 import { EventSystem } from '../system';
 import { ImageContext, ImageFile, ImageState } from './image-file';
-import { ImageTagStorage } from './image-tag-storage';
 
 export type CatalogItem = { identifier: string, state: number };
 
@@ -37,7 +36,6 @@ export class ImageStorage {
   async addAsync(blob: Blob): Promise<ImageFile>
   async addAsync(arg: any): Promise<ImageFile> {
     let image: ImageFile = await ImageFile.createAsync(arg);
-    await ImageTagStorage.instance.addAsync(image.identifier);
 
     return this._add(image);
   }
@@ -97,17 +95,6 @@ export class ImageStorage {
     let image: ImageFile = this.imageHash[identifier];
     if (image) return image;
     return null;
-  }
-
-  search(tag: string): ImageFile[] {
-    if (tag === 'all') return this.images;
-    let images: ImageFile[] = [];
-    for (let image of this.images) {
-      let imageTag = ImageTagStorage.instance.get(image.identifier);
-      if (!imageTag && tag === '') images.push(image);
-      if (imageTag && tag === imageTag.tag) images.push(image);
-    }
-    return images;
   }
 
   synchronize(peer?: string) {

--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -1,5 +1,6 @@
 import { EventSystem } from '../system';
 import { ImageContext, ImageFile, ImageState } from './image-file';
+import { ImageTagStorage } from './image-tag-storage';
 
 export type CatalogItem = { identifier: string, state: number };
 
@@ -36,6 +37,7 @@ export class ImageStorage {
   async addAsync(blob: Blob): Promise<ImageFile>
   async addAsync(arg: any): Promise<ImageFile> {
     let image: ImageFile = await ImageFile.createAsync(arg);
+    await ImageTagStorage.instance.addAsync(image.identifier);
 
     return this._add(image);
   }
@@ -95,6 +97,17 @@ export class ImageStorage {
     let image: ImageFile = this.imageHash[identifier];
     if (image) return image;
     return null;
+  }
+
+  search(tag: string): ImageFile[] {
+    if (tag === 'all') return this.images;
+    let images: ImageFile[] = [];
+    for (let image of this.images) {
+      let imageTag = ImageTagStorage.instance.get(image.identifier);
+      if (!imageTag && tag === '') images.push(image);
+      if (imageTag && tag === imageTag.tag) images.push(image);
+    }
+    return images;
   }
 
   synchronize(peer?: string) {

--- a/src/app/class/core/file-storage/image-tag-sharing-system.ts
+++ b/src/app/class/core/file-storage/image-tag-sharing-system.ts
@@ -27,10 +27,11 @@ export class ImageTagSharingSystem {
         for (let item of otherCatalog) {
           let imageTag: ImageTag = ImageTagStorage.instance.get(item.identifier);
           let itemVersion = item.imageTagContext.majorVersion + item.imageTagContext.minorVersion;
-          if (imageTag === null || imageTag.version < itemVersion) {
-            let updateImageTag = ImageTag.copy(item.imageTagContext);
-            ImageTagStorage.instance.add(updateImageTag);
+          if (!imageTag) {
+            imageTag = ImageTag.createEmpty(item.identifier);
+            ImageTagStorage.instance.add(imageTag);
           }
+          if (imageTag.version < itemVersion) imageTag.apply(item.imageTagContext);
         }
       });
   }

--- a/src/app/class/core/file-storage/image-tag-sharing-system.ts
+++ b/src/app/class/core/file-storage/image-tag-sharing-system.ts
@@ -1,0 +1,41 @@
+import { EventSystem } from '../system';
+import { ImageTagContext, ImageTag } from './image-tag';
+import { CatalogItem, ImageTagStorage } from './image-tag-storage';
+
+export class ImageTagSharingSystem {
+  private static _instance: ImageTagSharingSystem
+  static get instance(): ImageTagSharingSystem {
+    if (!ImageTagSharingSystem._instance) ImageTagSharingSystem._instance = new ImageTagSharingSystem();
+    return ImageTagSharingSystem._instance;
+  }
+
+  private constructor() {
+    console.log('ImageTagSharingSystem ready...');
+  }
+
+  initialize() {
+    EventSystem.register(this)
+      .on('CONNECT_PEER', 1, event => {
+        if (!event.isSendFromSelf) return;
+        console.log('CONNECT_PEER ImageTagStorageService !!!', event.data.peer);
+        ImageTagStorage.instance.synchronize();
+      })
+      .on('SYNCHRONIZE_IMAGETAG', event => {
+        if (event.isSendFromSelf) return;
+        console.log('SYNCHRONIZE_IMAGETAG ImageTagStorageService ' + event.sendFrom);
+        let otherCatalog: CatalogItem[] = event.data;
+        for (let item of otherCatalog) {
+          let imageTag: ImageTag = ImageTagStorage.instance.get(item.identifier);
+          let itemVersion = item.imageTagContext.majorVersion + item.imageTagContext.minorVersion;
+          if (imageTag === null || imageTag.version < itemVersion) {
+            let updateImageTag = ImageTag.copy(item.imageTagContext);
+            ImageTagStorage.instance.add(updateImageTag);
+          }
+        }
+      });
+  }
+
+  private destroy() {
+    EventSystem.unregister(this);
+  }
+}

--- a/src/app/class/core/file-storage/image-tag-storage.ts
+++ b/src/app/class/core/file-storage/image-tag-storage.ts
@@ -6,6 +6,8 @@ export type CatalogItem = { identifier: string, imageTagContext: ImageTagContext
 
 export class ImageTagStorage {
   inputTag: string = '';
+  isActive = false;
+
   private static _instance: ImageTagStorage
   static get instance(): ImageTagStorage {
     if (!ImageTagStorage._instance) ImageTagStorage._instance = new ImageTagStorage();
@@ -49,7 +51,8 @@ export class ImageTagStorage {
 
   async addAsync(identifier: string): Promise<ImageTag> {
     let imageTag: ImageTag = await ImageTag.createAsync(identifier, this.inputTag);
-    return this._add(imageTag);
+    if (this.isActive) return this._add(imageTag);
+    return imageTag;
   }
 
   add(imageTag: ImageTag): ImageTag {

--- a/src/app/class/core/file-storage/image-tag-storage.ts
+++ b/src/app/class/core/file-storage/image-tag-storage.ts
@@ -44,7 +44,7 @@ export class ImageTagStorage {
     for (let tagLine of tagLines) {
       let identifier = tagLine.split(",")[0];
       let tag = tagLine.split(",")[1];
-      let imageTag = await ImageTag.loadAsync(identifier, tag);
+      let imageTag = await ImageTag.createAsync(identifier, tag);
       this._add(imageTag);
     }
   }
@@ -78,7 +78,7 @@ export class ImageTagStorage {
     }
     let updatingImageTag: ImageTag = this.imageTagHash[imageTag.identifier];
     if (updatingImageTag) {
-      updatingImageTag.apply(context);
+      updatingImageTag.update(context);
       return true;
     }
     return false;

--- a/src/app/class/core/file-storage/image-tag-storage.ts
+++ b/src/app/class/core/file-storage/image-tag-storage.ts
@@ -1,0 +1,121 @@
+import { EventSystem } from '../system';
+import { ImageTagContext, ImageTag } from './image-tag';
+import { FileReaderUtil } from './file-reader-util';
+
+export type CatalogItem = { identifier: string, imageTagContext: ImageTagContext };
+
+export class ImageTagStorage {
+  inputTag: string = '';
+  private static _instance: ImageTagStorage
+  static get instance(): ImageTagStorage {
+    if (!ImageTagStorage._instance) ImageTagStorage._instance = new ImageTagStorage();
+    return ImageTagStorage._instance;
+  }
+
+  private imageTagHash: { [identifier: string]: ImageTag } = {};
+
+  get tags(): ImageTag[] {
+    let imageTags: ImageTag[] = [];
+    for (let identifier in this.imageTagHash) {
+      imageTags.push(this.imageTagHash[identifier]);
+    }
+    return imageTags;
+  }
+
+  private lazyTimer: NodeJS.Timer;
+
+  private constructor() {
+    console.log('ImageTagStorage ready...');
+  }
+
+  private destroy() {
+    for (let identifier in this.imageTagHash) {
+      this.delete(identifier);
+    }
+  }
+
+  async loadAsync(file: File): Promise<void>
+  async loadAsync(blob: Blob): Promise<void>
+  async loadAsync(arg: any): Promise<void> {
+    let tagCsvData: string = await FileReaderUtil.readAsTextAsync(arg);
+    let tagLines: string[] = tagCsvData.split("\r\n");
+    for (let tagLine of tagLines) {
+      let identifier = tagLine.split(",")[0];
+      let tag = tagLine.split(",")[1];
+      let imageTag = await ImageTag.loadAsync(identifier, tag);
+      imageTag.update();
+      this._add(imageTag);
+    }
+  }
+
+  async addAsync(identifier: string): Promise<ImageTag> {
+    let imageTag: ImageTag = await ImageTag.createAsync(identifier, this.inputTag);
+    imageTag.update();
+    return this._add(imageTag);
+  }
+
+  add(imageTag: ImageTag): ImageTag {
+    return this._add(imageTag);
+  }
+
+  private _add(imageTag: ImageTag): ImageTag {
+    this.lazySynchronize(100);
+    if (this.update(imageTag)) return this.imageTagHash[imageTag.identifier];
+    this.imageTagHash[imageTag.identifier] = imageTag;
+    console.log('addNewTag()', imageTag);
+    return imageTag;
+  }
+
+  private update(imageTag: ImageTag): boolean
+  private update(imageTag: ImageTagContext): boolean
+  private update(imageTag: any): boolean {
+    let context: ImageTagContext;
+    if (imageTag instanceof ImageTag) {
+      context = imageTag.toContext();
+    } else {
+      context = imageTag;
+    }
+    let updatingImageTag: ImageTag = this.imageTagHash[imageTag.identifier];
+    if (updatingImageTag) {
+      updatingImageTag.apply(context);
+      return true;
+    }
+    return false;
+  }
+
+  delete(identifier: string): boolean {
+    let deleteTag: ImageTag = this.imageTagHash[identifier];
+    if (deleteTag) {
+      delete this.imageTagHash[identifier];
+      return true;
+    }
+    return false;
+  }
+
+  get(identifier: string): ImageTag {
+    let imageTag: ImageTag = this.imageTagHash[identifier];
+    if (imageTag) return imageTag;
+    return null;
+  }
+
+  synchronize(peer?: string) {
+    clearTimeout(this.lazyTimer);
+    this.lazyTimer = null;
+    EventSystem.call('SYNCHRONIZE_IMAGETAG', this.getCatalog(), peer);
+  }
+
+  lazySynchronize(ms: number, peer?: string) {
+    clearTimeout(this.lazyTimer);
+    this.lazyTimer = setTimeout(() => {
+      this.synchronize(peer);
+    }, ms);
+  }
+
+  getCatalog(): CatalogItem[] {
+    let catalog: CatalogItem[] = [];
+    for (let imageTag of this.tags) {
+      catalog.push({ identifier: imageTag.identifier, imageTagContext: imageTag.toContext() });
+    }
+    return catalog;
+  }
+}

--- a/src/app/class/core/file-storage/image-tag-storage.ts
+++ b/src/app/class/core/file-storage/image-tag-storage.ts
@@ -43,14 +43,12 @@ export class ImageTagStorage {
       let identifier = tagLine.split(",")[0];
       let tag = tagLine.split(",")[1];
       let imageTag = await ImageTag.loadAsync(identifier, tag);
-      imageTag.update();
       this._add(imageTag);
     }
   }
 
   async addAsync(identifier: string): Promise<ImageTag> {
     let imageTag: ImageTag = await ImageTag.createAsync(identifier, this.inputTag);
-    imageTag.update();
     return this._add(imageTag);
   }
 

--- a/src/app/class/core/file-storage/image-tag.ts
+++ b/src/app/class/core/file-storage/image-tag.ts
@@ -1,9 +1,3 @@
-enum ImageState {
-  EMPTY = 0,
-  USER_CREATE = 1,
-  FILE_LOAD = 2,
-}
-
 export interface ImageTagContext {
   identifier: string;
   tag: string;
@@ -31,31 +25,30 @@ export class ImageTag {
     return imageTag;
   }
 
-  static async loadAsync(identifier: string, tag: string): Promise<ImageTag> {
-    let imageTag = new ImageTag();
-    imageTag.context.identifier = identifier;
-    imageTag.context.tag = tag;
-    imageTag.context.majorVersion = ImageState.FILE_LOAD;
-    imageTag.context.minorVersion = 0;
-    return imageTag;
-  }
-
   static async createAsync(identifier: string, tag: string): Promise<ImageTag> {
     let imageTag = new ImageTag();
     imageTag.context.identifier = identifier;
     imageTag.context.tag = tag;
-    imageTag.context.majorVersion = ImageState.USER_CREATE;
-    imageTag.context.minorVersion = 0;
+    imageTag.context.majorVersion = 1;
+    imageTag.context.minorVersion = Math.random();
     return imageTag;
   }
 
   apply(context: ImageTagContext) {
-    let version = context.majorVersion + context.minorVersion;
-    if (context && this.version < version) {
+    if (context) {
       if(!this.context.identifier && context.identifier) this.context.identifier = context.identifier; 
       this.context.tag = context.tag;
       this.context.majorVersion = context.majorVersion;
       this.context.minorVersion = context.minorVersion;
+    }
+  }
+
+  update(context: ImageTagContext) {
+    if (context) {
+      if(!this.context.identifier && context.identifier) this.context.identifier = context.identifier; 
+      this.context.tag = context.tag;
+      this.context.majorVersion += context.majorVersion;
+      this.context.minorVersion = Math.random();
     }
   }
 

--- a/src/app/class/core/file-storage/image-tag.ts
+++ b/src/app/class/core/file-storage/image-tag.ts
@@ -1,0 +1,69 @@
+export interface ImageTagContext {
+  identifier: string;
+  tag: string;
+  majorVersion: number;
+  minorVersion: number;
+}
+
+export class ImageTag {
+  private context: ImageTagContext = {
+    identifier: '',
+    tag: '',
+    majorVersion: 0,
+    minorVersion: 0,
+  }
+
+  get identifier() { return this.context.identifier; }
+  get tag() { return this.context.tag; }
+  get version() { return this.context.majorVersion + this.context.minorVersion; }
+
+  private constructor() {}
+
+  static copy(context: ImageTagContext): ImageTag {
+    let imageTag = new ImageTag();
+    imageTag.apply(context);
+    return imageTag;
+  }
+
+  static async createAsync(identifier: string, tag: string): Promise<ImageTag> {
+    let imageTag = new ImageTag();
+    imageTag.context.identifier = identifier;
+    imageTag.context.tag = tag;
+    imageTag.context.majorVersion = 0;
+    imageTag.context.minorVersion = 0;
+    return imageTag;
+  }
+
+  static async loadAsync(identifier: string, tag: string): Promise<ImageTag> {
+    let imageTag = new ImageTag();
+    imageTag.context.identifier = identifier;
+    imageTag.context.tag = tag;
+    imageTag.context.majorVersion = 1;
+    imageTag.context.minorVersion = Math.random();
+    return imageTag;
+  }
+
+  update() {
+    this.context.majorVersion += 1;
+    this.context.minorVersion = Math.random();
+  }
+
+  apply(context: ImageTagContext) {
+    let version = context.majorVersion + context.minorVersion;
+    if (context !== null && this.version < version) {
+      if(!this.context.identifier && context.identifier) this.context.identifier = context.identifier; 
+      this.context.tag = context.tag;
+      this.context.majorVersion = context.majorVersion;
+      this.context.minorVersion = context.minorVersion;
+    }
+  }
+
+  toContext(): ImageTagContext {
+    return {
+      identifier: this.context.identifier,
+      tag: this.context.tag,
+      majorVersion: this.context.majorVersion,
+      minorVersion: this.context.minorVersion,
+    }
+  }
+}

--- a/src/app/class/core/file-storage/image-tag.ts
+++ b/src/app/class/core/file-storage/image-tag.ts
@@ -1,3 +1,9 @@
+enum ImageState {
+  EMPTY = 0,
+  USER_CREATE = 1,
+  FILE_LOAD = 2,
+}
+
 export interface ImageTagContext {
   identifier: string;
   tag: string;
@@ -19,18 +25,9 @@ export class ImageTag {
 
   private constructor() {}
 
-  static copy(context: ImageTagContext): ImageTag {
-    let imageTag = new ImageTag();
-    imageTag.apply(context);
-    return imageTag;
-  }
-
-  static async createAsync(identifier: string, tag: string): Promise<ImageTag> {
+  static createEmpty(identifier: string): ImageTag {
     let imageTag = new ImageTag();
     imageTag.context.identifier = identifier;
-    imageTag.context.tag = tag;
-    imageTag.context.majorVersion = 0;
-    imageTag.context.minorVersion = 0;
     return imageTag;
   }
 
@@ -38,19 +35,23 @@ export class ImageTag {
     let imageTag = new ImageTag();
     imageTag.context.identifier = identifier;
     imageTag.context.tag = tag;
-    imageTag.context.majorVersion = 1;
-    imageTag.context.minorVersion = Math.random();
+    imageTag.context.majorVersion = ImageState.FILE_LOAD;
+    imageTag.context.minorVersion = 0;
     return imageTag;
   }
 
-  update() {
-    this.context.majorVersion += 1;
-    this.context.minorVersion = Math.random();
+  static async createAsync(identifier: string, tag: string): Promise<ImageTag> {
+    let imageTag = new ImageTag();
+    imageTag.context.identifier = identifier;
+    imageTag.context.tag = tag;
+    imageTag.context.majorVersion = ImageState.USER_CREATE;
+    imageTag.context.minorVersion = 0;
+    return imageTag;
   }
 
   apply(context: ImageTagContext) {
     let version = context.majorVersion + context.minorVersion;
-    if (context !== null && this.version < version) {
+    if (context && this.version < version) {
       if(!this.context.identifier && context.identifier) this.context.identifier = context.identifier; 
       this.context.tag = context.tag;
       this.context.majorVersion = context.majorVersion;

--- a/src/app/class/core/file-storage/image-tag.ts
+++ b/src/app/class/core/file-storage/image-tag.ts
@@ -47,7 +47,7 @@ export class ImageTag {
     if (context) {
       if(!this.context.identifier && context.identifier) this.context.identifier = context.identifier; 
       this.context.tag = context.tag;
-      this.context.majorVersion += context.majorVersion;
+      this.context.majorVersion += 1;
       this.context.minorVersion = Math.random();
     }
   }

--- a/src/app/class/core/file-storage/mime-type.ts
+++ b/src/app/class/core/file-storage/mime-type.ts
@@ -15,6 +15,7 @@ export namespace MimeType {
     xml: 'text/xml',
     yml: 'text/yaml',
     yaml: 'text/yaml',
+    csv: 'text/csv',
     json: 'application/json',
     map: 'application/json',
     zip: 'application/zip',

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,3 +1,8 @@
+<div id="input-tag">
+  <label>タグ
+    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示" />
+  </label>
+</div>
 <div id="file-list">
   <span class="empty" *ngIf="isAllowedEmpty">
     <button (click)="onSelectedFile(empty)">画像なし</button>

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,6 +1,6 @@
 <div id="input-tag">
   <label>タグ
-    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示" />
+    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示、上書き方式、カンマ不可" />
   </label>
 </div>
 <div id="file-list">

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -9,6 +9,7 @@ import {
 } from '@angular/core';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
+import { ImageTagStorage } from '@udonarium/core/file-storage/image-tag-storage';
 import { EventSystem, Network } from '@udonarium/core/system';
 import { ModalService } from 'service/modal.service';
 import { PanelService } from 'service/panel.service';
@@ -22,9 +23,20 @@ import { PanelService } from 'service/panel.service';
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() isAllowedEmpty: boolean = false;
-  get images(): ImageFile[] { return ImageStorage.instance.search(this.inputTag); }
+  get images(): ImageFile[] { return this.search(this.inputTag); }
   get empty(): ImageFile { return ImageFile.Empty; }
   inputTag: string = '';
+
+  private search(tag: string): ImageFile[] {
+    let imageFiles: ImageFile[] = [];
+    if (tag === 'all') return ImageStorage.instance.images;
+    for (let image of ImageStorage.instance.images) {
+      let imageTag = ImageTagStorage.instance.get(image.identifier);
+      if (!imageTag && tag === '') imageFiles.push(image);
+      if (imageTag && tag === imageTag.tag) imageFiles.push(image);
+    }
+    return imageFiles;
+  }
 
   constructor(
     private changeDetector: ChangeDetectorRef,

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -22,8 +22,9 @@ import { PanelService } from 'service/panel.service';
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @Input() isAllowedEmpty: boolean = false;
-  get images(): ImageFile[] { return ImageStorage.instance.images; }
+  get images(): ImageFile[] { return ImageStorage.instance.search(this.inputTag); }
   get empty(): ImageFile { return ImageFile.Empty; }
+  inputTag: string = '';
 
   constructor(
     private changeDetector: ChangeDetectorRef,

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -10,8 +10,13 @@
       <br>１ファイルにつき2MBまで</div>
   </div>
 </label>
+<div id="input-tag">
+  <label>タグ
+    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示" />
+  </label>
+</div>
 <div id="file-list">
-  <span *ngFor="let file of fileStorageService.images" class="image">
+  <span *ngFor="let file of images" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
   </span>

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -12,7 +12,7 @@
 </label>
 <div id="input-tag">
   <label>タグ
-    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示" />
+    <input type="text" [(ngModel)]="inputTag" name="inputTag" placeholder="allで全て表示、上書き方式、カンマ不可" />
   </label>
 </div>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -22,9 +22,20 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     private panelService: PanelService
   ) { }
 
-  get images(): ImageFile[] { return this.fileStorageService.search(this.inputTag); }
+  get images(): ImageFile[] { return this.search(this.inputTag); }
   get inputTag(): string { return ImageTagStorage.instance.inputTag; }
   set inputTag(inputTag: string) { ImageTagStorage.instance.inputTag = inputTag; }
+
+  private search(tag: string): ImageFile[] {
+    let imageFiles: ImageFile[] = [];
+    if (tag === 'all') return this.fileStorageService.images;
+    for (let image of this.fileStorageService.images) {
+      let imageTag = ImageTagStorage.instance.get(image.identifier);
+      if (!imageTag && tag === '') imageFiles.push(image);
+      if (imageTag && tag === imageTag.tag) imageFiles.push(image);
+    }
+    return imageFiles;
+  }
 
   ngOnInit() {
     this.panelService.title = 'ファイル一覧';

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -28,6 +28,7 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
 
   ngOnInit() {
     this.panelService.title = 'ファイル一覧';
+    ImageTagStorage.instance.isActive = true;
   }
 
   ngAfterViewInit() {
@@ -39,6 +40,7 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   ngOnDestroy() {
+    ImageTagStorage.instance.isActive = false;
     EventSystem.unregister(this);
   }
 

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -3,6 +3,7 @@ import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, O
 import { FileArchiver } from '@udonarium/core/file-storage/file-archiver';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
+import { ImageTagStorage } from '@udonarium/core/file-storage/image-tag-storage';
 import { EventSystem, Network } from '@udonarium/core/system';
 
 import { PanelService } from 'service/panel.service';
@@ -20,6 +21,10 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     private changeDetector: ChangeDetectorRef,
     private panelService: PanelService
   ) { }
+
+  get images(): ImageFile[] { return this.fileStorageService.search(this.inputTag); }
+  get inputTag(): string { return ImageTagStorage.instance.inputTag; }
+  set inputTag(inputTag: string) { ImageTagStorage.instance.inputTag = inputTag; }
 
   ngOnInit() {
     this.panelService.title = 'ファイル一覧';


### PR DESCRIPTION
### 概要
#56 で提案されている画像へのタグ機能の追加です．
~~ただし，画像の削除には対応していません．~~ 
疑似的にではありますが「ゴミ箱」タグなどを作れば削除相当の機能が使えます

### 詳細
追加したファイルは以下の３つです．
・image-tag.ts
・image-tag-storage.ts
・image-tag-sharing-system.ts

変更したファイルは以下の９つです．
・app.component.ts
・file-archiver.ts
~~・image-storage.ts~~
・file-selector.component.ts
・file-selector.component.html
・file-storage.component.ts
・file-storage.component.html
・save-data.ts
・mime-type.ts

新規ファイルは以下の内容です．
・image-tag.ts
　ユーザー間で共有するタグを定義しています．
　identifierはimage-fileと共通です．
　~~変化の少ない~~ 動的なデータを想定しています．
　ユーザー間では最もバージョンの大きいタグが共有されます．
　主に使用する関数は以下の通りです．
　・static async createAsync(identifier: string, tag: string): Promise<ImageTag>
　　ユーザーがimage-storageからタグを作成する際に使用します．
　　~~image-storageのaddAsync()と同じタイミングで動作します．~~
　削除 ~~・static async loadAsync(identifier: string, tag: string): Promise<ImageTag>
　　zip読み込みの際に使用します．
　　file-archiverが使用します．
　　zip読み込みを優先するために最初から大きい初期値をバージョンに設定しています．~~
　
・image-tag-storage.ts
　タグを管理するクラスです．
　image-storgeからかなりコードを流用しています．
　主に使用する関数は以下の通りです．
　・async loadAsync(file: File): Promise<void>
　　zip読み込みの際に使用します．
　　"identifier,tag"という形式で保存されたcsvファイルからstringでidentifierとtagを読み込みます．
　　~~タグは更新するかもしれないのでimage.update()を挟んでいます．~~ ~~更新機能は使用できません．~~
　・async addAsync(identifier: string): Promise<ImageTag>
　　ユーザーがimage-storageからタグを設定する際に使用します．
　　image-storageのaddAsync()と同じタイミングで動作します．
　　~~タグは更新するかもしれないのでimage.update()を挟んでいます．~~ ~~更新機能は使用できません．~~
　・add(imageTag: ImageTag): ImageTag
　　同期の際に使用します．
　　image-tag-sharing-systemが使用します．
　・synchronize(peer?: string)
　　所有する全てのタグを送信します．

・image-tag-sharing-system.ts
　自分の持つタグのバージョンより大きいバージョンのタグを受信したら更新します．


変更点は以下の内容です．
・save-data.ts
　保存する画像を取得してタグと一緒にcsvに保存します．
　csvは"identifier,tag"という形式です．

・file-archiver.ts
　csvをzipから読み出し，image-tag-storageに渡します．
　csvはzipに入ってないとうまく動作しません．

・file-selector.component.ts
・file-selector.component.html
・file-storage.component.ts
・file-storage.component.html
~~・image-storage.ts~~
　タグを使って検索できるようにしました．

・app.component.ts
　新規追加したクラスの初期化などを追加しました．

・mime-type.ts
　csvを追加しました．

### 懸念点
・image-tag-sharing-systemがsyncronize()する度に所有する全てのタグを相手に送信します．それほど大きなデータではないので今回はこのまま実装しましたが、もしかしたらタグを個別に要求する機能を付けたほうがいいかもしれません．
・csv書き出しおよびcsv読み込みが手作り感満載なのでバグのもとになるかもしれません．

~~### 追記
タグの更新機能がおかしかったので削除しました．
現在はバージョンを定数で設定しています．
設定の優先度としては以下のようになっています．
　zip読み込み　>　ユーザがテキストボックスで設定
zip読み込みで設定したタグをzip読み込みで上書きすることは出来ません．
ユーザが設定したタグをユーザが上書きすることは出来ません．
そのため，以下の全ての条件を満たす場合に不整合が発生します．
・同一の画像
・同一の設定方法（zip読み込み，テキストボックス）
・異なるユーザーが異なるタグを設定~~
