### PR TITLE
チャット画面 / チャットパレットのアイコンから画像変更画面を開く

### DIFF
--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -31,7 +31,7 @@
         <div>
           <form>
             <!--<input [(ngModel)]="text" placeholder="message" [ngModelOptions]="{standalone: true}" style="width: 25em;">-->
-            <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
+            <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行  アイコンクリックで画像変更" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
             <button type="submit" (click)="sendChat(null)">SEND</button>
           </form>
         </div>

--- a/src/app/component/chat-palette/chat-palette.component.html
+++ b/src/app/component/chat-palette/chat-palette.component.html
@@ -10,7 +10,7 @@
     </form>
     <div class="table" [ngClass]="{ 'direct-message': isDirect }">
       <div class="table-cell imagebox">
-        <img class="image" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
+        <img class="image" (click)="openCharacterImageChange()" *ngIf="character && character.imageFile != null && 0 < character.imageFile.url.length" [src]="character.imageFile.url | safe: 'resourceUrl'"
         />
       </div>
       <div class="table-cell">

--- a/src/app/component/chat-palette/chat-palette.component.ts
+++ b/src/app/component/chat-palette/chat-palette.component.ts
@@ -14,6 +14,9 @@ import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 
+import { FileSelecterComponent } from 'component/file-selecter/file-selecter.component';
+import { ModalService } from 'service/modal.service';
+
 @Component({
   selector: 'chat-palette',
   templateUrl: './chat-palette.component.html',
@@ -65,7 +68,8 @@ export class ChatPaletteComponent implements OnInit, OnDestroy {
   constructor(
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private modalService: ModalService
   ) { }
 
   ngOnInit() {
@@ -243,4 +247,14 @@ export class ChatPaletteComponent implements OnInit, OnDestroy {
         return true;
     }
   }
+
+  openCharacterImageChange() {
+    this.modalService.open<string>(FileSelecterComponent, { isAllowedEmpty: true }).then(value => {
+      if (!this.character || !this.character.imageDataElement || !value) return;
+      let element = this.character.imageDataElement.getFirstElementByName('imageIdentifier');
+      if (!element) return;
+      element.value = value;
+    });
+  }
+
 }

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -39,7 +39,7 @@
     </div>
     <div>
       <form #chatWindowForm="ngForm">
-        <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
+        <textarea #textArea [(ngModel)]="text" placeholder="Enterで送信  Shift+Enterで改行  アイコンクリックで画像変更" [ngModelOptions]="{standalone: true}" class="chat-input" (input)="onInput()" (keydown.enter)="sendChat($event)"></textarea>
         <button type="submit" (click)="sendChat(null)">SEND</button>
       </form>
     </div>

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -16,7 +16,7 @@
   </form>
 <div class="table" [ngClass]="{'direct-message': isDirect}">
   <div class="table-cell imagebox">
-    <img class="image" *ngIf="gameCharacter && gameCharacter.imageFile != null && 0 < gameCharacter.imageFile?.url?.length" [src]="gameCharacter.imageFile?.url | safe: 'resourceUrl'"
+    <img class="image" (click)="openCharacterImageChange()" *ngIf="gameCharacter && gameCharacter.imageFile != null && 0 < gameCharacter.imageFile?.url?.length" [src]="gameCharacter.imageFile?.url | safe: 'resourceUrl'"
     />
     <img class="image" *ngIf="!gameCharacter && myPeer && myPeer?.image != null" [src]="myPeer?.image?.url | safe: 'resourceUrl'"
     />

--- a/src/app/component/chat-window/chat-window.component.html
+++ b/src/app/component/chat-window/chat-window.component.html
@@ -18,7 +18,7 @@
   <div class="table-cell imagebox">
     <img class="image" (click)="openCharacterImageChange()" *ngIf="gameCharacter && gameCharacter.imageFile != null && 0 < gameCharacter.imageFile?.url?.length" [src]="gameCharacter.imageFile?.url | safe: 'resourceUrl'"
     />
-    <img class="image" *ngIf="!gameCharacter && myPeer && myPeer?.image != null" [src]="myPeer?.image?.url | safe: 'resourceUrl'"
+    <img class="image" (click)="openPeerIconChange()" *ngIf="!gameCharacter && myPeer && myPeer?.image != null" [src]="myPeer?.image?.url | safe: 'resourceUrl'"
     />
   </div>
   <div class="table-cell">

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -16,6 +16,9 @@ import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 
+import { FileSelecterComponent } from 'component/file-selecter/file-selecter.component';
+import { ModalService } from 'service/modal.service';
+
 @Component({
   selector: 'chat-window',
   templateUrl: './chat-window.component.html',
@@ -94,7 +97,8 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     private ngZone: NgZone,
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private modalService: ModalService
   ) { }
 
   ngOnInit() {
@@ -321,5 +325,16 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
   trackByChatTab(index: number, chatTab: ChatTab) {
     return chatTab.identifier;
+  }
+
+  openCharacterImageChange() {
+    this.modalService.open<string>(FileSelecterComponent, { isAllowedEmpty: true }).then(value => {
+      if (!this.gameCharacter || !this.gameCharacter.imageDataElement || !value) return;
+      let element = this.gameCharacter.imageDataElement.getFirstElementByName('imageIdentifier');
+      if (!element) return;
+      element.value = value;
+    });
+
+    return;
   }
 }

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -337,4 +337,14 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
 
     return;
   }
+
+  openPeerIconChange() {
+    this.modalService.open<string>(FileSelecterComponent).then(value => {
+      if (!this.myPeer || !value) return;
+      this.myPeer.imageIdentifier = value;
+    });
+
+    return;
+    
+  }
 }


### PR DESCRIPTION
## 概要
　チャットウィンドウおよびチャットパレットのアイコンをクリックすると、該当のキャラクターコマの画像変更ウィンドウが開くようにしました。変更すると、キャラクターコマの「画像変更」を押したときと同様に、コマの画像変更（と、他参加者への反映）が行われます。
　チャット中、表情差分や変身などの契機で、咄嗟にキャラクターアイコンを変更したい場合を想定しています。

## 修正点
- チャットウィンドウのアイコンをクリックすると、対応したキャラクターコマの画像選択ウィンドウがモーダルで開きます。

- 発話者の選択が「自分のニックネーム（あなた）」の場合は、自分のアイコンを変更するウィンドウが開きます。（接続情報ウィンドウの「アイコンを変更する」ボタンと同じ）

- いずれも、変更した場合は通常通り画像変更した場合と同様、ボードの上のキャラクター画像に反映され、他の人にも共有されます。

- チャット入力ボックスのデフォルト欄に、「アイコンクリックで画像変更」という一文を加えました。（機能追加だけだと、ウィンドウが開くことに気づけないため）

（以上）