### PR TITLE
インベントリにて標準のダイスボットを設定できるよう機能追加 (Issue #42)

### DIFF
--- a/src/app/class/data-summary-setting.ts
+++ b/src/app/class/data-summary-setting.ts
@@ -22,6 +22,7 @@ export class DataSummarySetting extends GameObject implements InnerXml {
   @SyncVar() sortTag: string = 'name';
   @SyncVar() sortOrder: SortOrder = SortOrder.ASC;
   @SyncVar() dataTag: string = 'HP MP 敏捷度 生命力 精神力';
+  @SyncVar() gameType: string = "";
 
   private _dataTag: string;
   private _dataTags: string[];

--- a/src/app/component/chat-palette/chat-palette.component.ts
+++ b/src/app/component/chat-palette/chat-palette.component.ts
@@ -13,6 +13,7 @@ import { TextViewComponent } from 'component/text-view/text-view.component';
 import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { GameObjectInventoryService} from 'service/game-object-inventory.service';
 
 @Component({
   selector: 'chat-palette',
@@ -65,13 +66,20 @@ export class ChatPaletteComponent implements OnInit, OnDestroy {
   constructor(
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private inventoryService: GameObjectInventoryService
   ) { }
 
   ngOnInit() {
     this.panelService.title = this.character.name + ' のチャットパレット';
     this.chatTabidentifier = this.chatMessageService.chatTabs ? this.chatMessageService.chatTabs[0].identifier : '';
-    this.gameType = this.character.chatPalette ? this.character.chatPalette.dicebot : '';
+
+    if(this.character.chatPalette != null && this.character.chatPalette.dicebot != '') {
+      this.gameType = this.character.chatPalette.dicebot;
+    } else {
+      this.gameType = this.inventoryService.gameType;
+    }
+
     EventSystem.register(this)
       .on('UPDATE_GAME_OBJECT', -1000, event => {
         if (event.data.aliasName !== GameCharacter.aliasName) return;

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -15,6 +15,7 @@ import { TextViewComponent } from 'component/text-view/text-view.component';
 import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { GameObjectInventoryService} from 'service/game-object-inventory.service';
 
 @Component({
   selector: 'chat-window',
@@ -94,13 +95,15 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
     private ngZone: NgZone,
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private inventoryService: GameObjectInventoryService
   ) { }
 
   ngOnInit() {
     this.sender = this.myPeer.identifier;
     this._chatTabidentifier = 0 < this.chatMessageService.chatTabs.length ? this.chatMessageService.chatTabs[0].identifier : '';
-
+    this.gameType = this.inventoryService.gameType;
+    
     EventSystem.register(this)
       .on('MESSAGE_ADDED', event => {
         let message = ObjectStore.instance.get<ChatMessage>(event.data.messageIdentifier);

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -32,6 +32,11 @@
     </div>
     <div style="font-size: 12px; padding-top: 6px;">表示項目</div>
     <input style="width: 100%; box-sizing: border-box;" [(ngModel)]="dataTag" placeholder="スペース区切りでタグ名 スラッシュで改行 ex.「HP MP / メモ」" />
+    <div style="font-size: 12px; padding-top: 6px;">標準ダイスボット</div>
+    <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
+      <option value="">ダイスボット指定なし</option>
+      <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
+    </select>
     <div style="padding-top: 6px;">
       <button class="tab-setting small-font" (click)="toggleEdit()"><i class="material-icons small-font">settings</i>完了</button>
     </div>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -15,6 +15,7 @@ import { ContextMenuAction, ContextMenuService, ContextMenuSeparator } from 'ser
 import { GameObjectInventoryService } from 'service/game-object-inventory.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { DiceBot } from '@udonarium/dice-bot';
 
 @Component({
   selector: 'game-object-inventory',
@@ -37,6 +38,9 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   get dataTag(): string { return this.inventoryService.dataTag; }
   set dataTag(dataTag: string) { this.inventoryService.dataTag = dataTag; }
   get dataTags(): string[] { return this.inventoryService.dataTags; }
+  get diceBotInfos() { return DiceBot.diceBotInfos }
+  get gameType(): string { return this.inventoryService.gameType; }
+  set gameType(gameType: string) { this.inventoryService.gameType = gameType; }
 
   get sortOrderName(): string { return this.sortOrder === SortOrder.ASC ? '昇順' : '降順'; }
 
@@ -213,5 +217,12 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   trackByGameObject(index: number, gameObject: GameObject) {
     return gameObject ? gameObject.identifier : index;
+  }
+
+  onChangeGameType(gameType: string) {
+    console.log('onChangeGameType ready');
+    DiceBot.getHelpMessage(this.gameType).then(help => {
+      console.log('onChangeGameType done\n' + help + this.gameType);
+    });
   }
 }

--- a/src/app/service/game-object-inventory.service.ts
+++ b/src/app/service/game-object-inventory.service.ts
@@ -24,6 +24,8 @@ export class GameObjectInventoryService {
   get dataTag(): string { return this.summarySetting.dataTag; }
   set dataTag(dataTag: string) { this.summarySetting.dataTag = dataTag; }
   get dataTags(): string[] { return this.summarySetting.dataTags; }
+  get gameType(): string { return this.summarySetting.gameType; }
+  set gameType(gameType: string) {this.summarySetting.gameType = gameType; }
 
   tableInventory: ObjectInventory = new ObjectInventory(object => { return object.location.name === 'table'; });
   commonInventory: ObjectInventory = new ObjectInventory(object => { return !this.isAnyLocation(object.location.name); });


### PR DESCRIPTION
## 概要
　チャット画面、および未設定のチャットパレットのダイスボットが「ダイスボット指定なし」に固定されている点が不便に感じたため、ルームの標準ダイスボットが設定できるよう機能追加を行いました。(Issue #42 の実装です)

## 仕様詳細

- インベントリの設定項目の中に「標準ダイスボット」を追加

- 設定した標準ダイスボットは、インベントリ設定と同様に、他の参加者にも共有される

- 「チャット画面」を新しく開いたときに、標準ダイスボットに設定したダイスボットが自動で選択される

- チャットパレットを開いた際に、標準ダイスボットに設定したダイスボットが自動で選択される。ただし、チャットパレットで別途ダイスボットを指定していた場合、そちらが優先される

- 設定した標準ダイスボットは、ルームデータの「summary.xml」内に保存され、ルームデータをロードすると保存された標準ダイスボットが自動で設定される

## 懸念点

- 本来、インベントリと無関係な標準ダイスボットをインベントリの設定項目のひとつとして扱っている点。（他に、いい場所が思いつきませんでした）