### PR TITLE
入室時のニックネームにランダムで番号を付与

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -131,7 +131,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     AudioStorage.instance.get(PresetSound.sweep).isHidden = true;
 
     PeerCursor.createMyCursor();
-    PeerCursor.myCursor.name = 'プレイヤー';
+    PeerCursor.myCursor.name = 'プレイヤー' + Math.floor(Math.random() * 1000);
     PeerCursor.myCursor.imageIdentifier = noneIconImage.identifier;
 
     EventSystem.register(this)

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -131,7 +131,7 @@ export class AppComponent implements AfterViewInit, OnDestroy {
     AudioStorage.instance.get(PresetSound.sweep).isHidden = true;
 
     PeerCursor.createMyCursor();
-    PeerCursor.myCursor.name = 'プレイヤー' + Math.floor(Math.random() * 1000);
+    PeerCursor.myCursor.name = 'プレイヤー' + ('000' + (Math.floor(Math.random() * 1000))).slice(-3);
     PeerCursor.myCursor.imageIdentifier = noneIconImage.identifier;
 
     EventSystem.register(this)


### PR DESCRIPTION
## 概要
　入室時、結構な割合で（面倒くさいのか）プレイヤーのニックネームを「プレイヤー」のままにしてプレイする人がいるため、チャット入力中の表示等が分かりにくくなる場合があります。
　若干不便なので、ランダムで番号を振るようにしました。

## 詳細な仕様
- 入室時のニックネームが「プレイヤーnnn」(nは0-9の数字)になります。nはランダムで決まります。

## 懸念点
- 変えてない人に一声かければいいじゃん、と言えばその通りなので、追加が必要かどうかはお任せします。不要と思ったらRejectしてください。

- 性質上、ごくごくまれに番号が被りますが、被ったとしてもフォローがきくものとしてそのままにしてあります。
