### PR TITLE
feat: 前回入力したニックネームを保持して初期表示後に使用できるように

### DIFF
--- a/src/app/class/database/database.ts
+++ b/src/app/class/database/database.ts
@@ -6,10 +6,16 @@ interface PeerHistory {
   history: string[]
 }
 
+interface NicknameHistory {
+  peerId: string,
+  timestamp: number,
+  nickname: string
+}
+
 // 試験実装中
 export class Database {
   private static DB_NAME: string = 'UdonariumDataBase';
-  private static VERSION: number = 1;
+  private static VERSION: number = 2;
 
   private queue: PromiseQueue = new PromiseQueue('DatabaseQueue');
   private db: IDBDatabase;
@@ -55,12 +61,15 @@ export class Database {
     if (this.db.objectStoreNames.contains('PeerHistory')) {
       this.db.deleteObjectStore('PeerHistory');
     }
-    let objectStore = this.db.createObjectStore('PeerHistory', { keyPath: 'peerId' });
-    objectStore.createIndex('timestamp', 'timestamp', { unique: false });
-    // データを追加する前に objectStore の作成を完了させるため、 
+    if (this.db.objectStoreNames.contains('NicknameHistory')) {
+      this.db.deleteObjectStore('NicknameHistory');
+    }
+    const peerObjectStore = this.db.createObjectStore('PeerHistory', { keyPath: 'peerId' });
+    peerObjectStore.createIndex('timestamp', 'timestamp', { unique: false });
+    // データを追加する前に objectStore の作成を完了させるため、
     // transaction oncomplete を使用します。
-    objectStore.transaction.oncomplete = (event) => {
-      console.log('createStores oncomplete');
+    peerObjectStore.transaction.oncomplete = (event) => {
+      console.log('PeerHistory createStores oncomplete');
       // 新たに作成した objectStore に値を保存します。
       /*
       var customerObjectStore = db.transaction("customers", "readwrite").objectStore("customers");
@@ -68,6 +77,11 @@ export class Database {
         customerObjectStore.add(customerData[i]);
       }
       */
+    };
+    const nicknameObjectStore = this.db.createObjectStore('NicknameHistory', { keyPath: 'peerId' });
+    nicknameObjectStore.createIndex('timestamp', 'timestamp', { unique: false });
+    peerObjectStore.transaction.oncomplete = (event) => {
+      console.log('NicknameHistory createStores oncomplete');
     };
   }
 
@@ -160,6 +174,86 @@ export class Database {
 
       request.onsuccess = (event) => {
         let cursor: IDBCursorWithValue = request.result;
+        if (cursor) {
+          console.log('id:' + cursor.key + ' value:', cursor.value);
+          history.push(cursor.value);
+          cursor.continue();
+        } else {
+          console.log('Entries all displayed.');
+        }
+      };
+    });
+  }
+
+  addNicknameHistory(myPeer: string, nickname: string) {
+    this.queue.add((resolve, reject) => {
+      console.log('addNicknameHistory');
+      const transaction = this.db.transaction(['NicknameHistory'], 'readwrite');
+      const store = transaction.objectStore('NicknameHistory');
+
+      transaction.oncomplete = (event) => {
+        console.log('addNicknameHistory done.', 'readwrite');
+        resolve();
+      };
+
+      transaction.onerror = (event) => {
+        console.error(event);
+        resolve();
+      };
+
+      const history: NicknameHistory = {
+        peerId: myPeer,
+        timestamp: Date.now(),
+        nickname: nickname
+      };
+
+      store.put(history);
+    });
+  }
+
+  deleteNicknameHistory(peerId: string) {
+    this.queue.add((resolve, reject) => {
+      const transaction = this.db.transaction(['NicknameHistory'], 'readwrite');
+      const store = transaction.objectStore('NicknameHistory');
+      transaction.oncomplete = (event) => {
+        console.log('addNicknameHistory done.', 'readwrite');
+        resolve();
+      };
+
+      transaction.onerror = (event) => {
+        console.error(event);
+        resolve();
+      };
+
+      store.delete(peerId);
+    });
+  }
+
+  getNicknameHistory(): Promise<NicknameHistory[]> {
+    return this.queue.add((resolve, reject) => {
+      console.log('getNicknameHistory');
+      const transaction = this.db.transaction(['NicknameHistory'], 'readonly');
+      const store = transaction.objectStore('NicknameHistory');
+      const request = store.openCursor();
+      const history: NicknameHistory[] = [];
+
+      transaction.oncomplete = (event) => {
+        console.log('getNicknameHistory done.');
+        resolve(history);
+      };
+
+      transaction.onerror = (event) => {
+        console.error(event);
+        resolve(history);
+      };
+
+      request.onerror = (event) => {
+        console.error(event);
+        resolve(history);
+      };
+
+      request.onsuccess = (event) => {
+        const cursor: IDBCursorWithValue = request.result;
         if (cursor) {
           console.log('id:' + cursor.key + ' value:', cursor.value);
           history.push(cursor.value);

--- a/src/app/component/peer-menu/peer-menu.component.html
+++ b/src/app/component/peer-menu/peer-menu.component.html
@@ -4,7 +4,7 @@
     (click)="changeIcon()">
     <!--<img *ngIf="myPeer.image" [src]="myPeer.image.url | safe: 'resourceUrl'" />-->
   </div>
-  <span>あなたのニックネーム：  <input [(ngModel)]="myPeer.name"  placeholder="ニックネーム" /></span>
+  <span>あなたのニックネーム： <input [(ngModel)]="myPeer.name" placeholder="ニックネーム" (change)="onChangeNickname()" (blur)="onBlurNickname()" /></span>
 </div>
 <div>
   <span>あなたのID：<span *ngIf="networkService.isOpen" style="font-weight: bold;">{{networkService.peerContext.id}}</span>

--- a/src/app/component/peer-menu/peer-menu.component.ts
+++ b/src/app/component/peer-menu/peer-menu.component.ts
@@ -23,6 +23,8 @@ export class PeerMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   gameRoomService = ObjectStore.instance;
   help: string = '';
 
+  private isChangedNickname: boolean = false;
+
   get myPeer(): PeerCursor { return PeerCursor.myCursor; }
 
   constructor(
@@ -156,5 +158,15 @@ export class PeerMenuComponent implements OnInit, OnDestroy, AfterViewInit {
   findPeerName(peerId: string) {
     const peerCursor = PeerCursor.find(peerId);
     return peerCursor ? peerCursor.name : '';
+  }
+
+  onChangeNickname(): void {
+    this.isChangedNickname = true;
+  }
+
+  onBlurNickname(): void {
+    if (this.isChangedNickname) {
+      EventSystem.call('CHANGE_NICKNAME', this.myPeer.name, this.myPeer.peerId);
+    }
   }
 }


### PR DESCRIPTION
# 概要
ニックネームの変更履歴を IndexedDB に保持して、
画面を開いたときに最新の履歴を取得して設定するようになります。

過去に存在した PeerHistory の実装を参考にしています。

#91 で上がってる要望もこれで解決できると思います。