### PR TITLE
Issues #56 画像へのタグ付与機能（別実装）

### DIFF
--- a/src/app/class/core/file-storage/image-storage.ts
+++ b/src/app/class/core/file-storage/image-storage.ts
@@ -57,6 +57,7 @@ export class ImageStorage {
   }
 
   private _add(image: ImageFile): ImageFile {
+    EventSystem.call('ADD_IMAGE', image.identifier);
     this.lazySynchronize(100);
     if (this.update(image)) return this.imageHash[image.identifier];
     this.imageHash[image.identifier] = image;

--- a/src/app/class/image-tag.ts
+++ b/src/app/class/image-tag.ts
@@ -1,0 +1,8 @@
+import { SyncObject, SyncVar } from './core/synchronize-object/decorator';
+import { ObjectNode } from './core/synchronize-object/object-node';
+
+@SyncObject('image-tag')
+export class ImageTag extends ObjectNode {
+  @SyncVar() imageIdentifier: string = '';
+  @SyncVar() tag: string = '';
+}

--- a/src/app/component/file-selecter/file-selecter.component.html
+++ b/src/app/component/file-selecter/file-selecter.component.html
@@ -1,3 +1,6 @@
+<div id="input-tag">
+  タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
+</div>
 <div id="file-list">
   <span class="empty" *ngIf="isAllowedEmpty">
     <button (click)="onSelectedFile(empty)">画像なし</button>

--- a/src/app/component/file-selecter/file-selecter.component.ts
+++ b/src/app/component/file-selecter/file-selecter.component.ts
@@ -12,6 +12,8 @@ import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
 import { EventSystem, Network } from '@udonarium/core/system';
 import { ModalService } from 'service/modal.service';
 import { PanelService } from 'service/panel.service';
+import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
+import { ImageTag } from '@udonarium/image-tag';
 
 @Component({
   selector: 'file-selector',
@@ -20,9 +22,25 @@ import { PanelService } from 'service/panel.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileSelecterComponent implements OnInit, OnDestroy, AfterViewInit {
+  private inputTag = '';
 
   @Input() isAllowedEmpty: boolean = false;
-  get images(): ImageFile[] { return ImageStorage.instance.images; }
+  get images(): ImageFile[] {
+    if (this.inputTag == 'all') return ImageStorage.instance.images;
+    let allImages = ImageStorage.instance.images;
+    let searchIdentifiers = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                              .filter(imageTag => imageTag.tag == this.inputTag)
+                              .map(imageTag => imageTag.imageIdentifier);
+    let searchImages = allImages.filter(image => searchIdentifiers.includes(image.identifier));
+    //タグを持っていない画像も表示する
+    if (this.inputTag == '') {
+      let identifiers = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                          .map(imageTag => imageTag.imageIdentifier);
+      let noTagImages = allImages.filter(image => !identifiers.includes(image.identifier));
+      searchImages = noTagImages.concat(searchImages);
+    }
+    return searchImages;
+  }
   get empty(): ImageFile { return ImageFile.Empty; }
 
   constructor(

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -10,8 +10,14 @@
       <br>１ファイルにつき2MBまで</div>
   </div>
 </label>
+<div id="input-tag">
+  タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
+</div>
+<div id="delte-tag">
+  <button (click)="deleteTag()">選択した画像からタグを削除</button>
+</div>
 <div id="file-list">
-  <span *ngFor="let file of fileStorageService.images" class="image">
+  <span *ngFor="let file of images" class="image">
     <img *ngIf="0 < file.url.length" [src]="file.url | safe: 'resourceUrl'" [alt]="file.name" height="120" (click)="onSelectedFile(file)">
     <img *ngIf="file.url.length <= 0" src="assets/images/loading.gif" alt="{{file.name}}">
   </span>

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -13,8 +13,8 @@
 <div id="input-tag">
   タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
 </div>
-<div id="delte-tag">
-  <button (click)="deleteTag()">選択した画像をgarbageタグへ移動</button>
+<div id="move-to-garbage">
+  <button (click)="moveToGarbage()">選択した画像をgarbageタグへ移動</button>
 </div>
 <div id="file-list">
   <span *ngFor="let file of images" class="image">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -13,7 +13,7 @@
 <div id="input-tag">
   タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
 </div>
-<div id="delete-tag">
+<div id="delte-tag">
   <button (click)="deleteTag()">選択した画像をgarbageタグへ移動</button>
 </div>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -13,7 +13,7 @@
 <div id="input-tag">
   タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
 </div>
-<div id="delte-tag">
+<div id="delete-tag">
   <button (click)="deleteTag()">選択した画像をgarbageタグへ移動</button>
 </div>
 <div id="file-list">

--- a/src/app/component/file-storage/file-storage.component.html
+++ b/src/app/component/file-storage/file-storage.component.html
@@ -14,7 +14,7 @@
   タグ <input type="text" [(ngModel)]="inputTag" placeholder="allで全て表示" />
 </div>
 <div id="delte-tag">
-  <button (click)="deleteTag()">選択した画像からタグを削除</button>
+  <button (click)="deleteTag()">選択した画像をgarbageタグへ移動</button>
 </div>
 <div id="file-list">
   <span *ngFor="let file of images" class="image">

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -84,7 +84,11 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     if(!this.selectedFile) return;
     let imageFile = ImageStorage.instance.get(this.selectedFile.identifier);
     let imageTags = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
-                     .filter(imageTag => imageTag.imageIdentifier == imageFile.identifier);
+                      .filter(imageTag => imageTag.imageIdentifier == imageFile.identifier)
     imageTags.forEach(imageTag => imageTag.destroy());
+    let imageTag: ImageTag = new ImageTag();
+    imageTag.imageIdentifier = this.selectedFile.identifier;
+    imageTag.tag = 'garbage';
+    imageTag.initialize();
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -4,6 +4,8 @@ import { FileArchiver } from '@udonarium/core/file-storage/file-archiver';
 import { ImageFile } from '@udonarium/core/file-storage/image-file';
 import { ImageStorage } from '@udonarium/core/file-storage/image-storage';
 import { EventSystem, Network } from '@udonarium/core/system';
+import { ObjectStore } from '@udonarium/core/synchronize-object/object-store';
+import { ImageTag } from '@udonarium/image-tag';
 
 import { PanelService } from 'service/panel.service';
 
@@ -14,8 +16,26 @@ import { PanelService } from 'service/panel.service';
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
+  private inputTag: string = '';
+  private selectedFile: ImageFile = null;
 
-  fileStorageService = ImageStorage.instance;
+  get images(): ImageFile[] {
+    if (this.inputTag == 'all') return ImageStorage.instance.images;
+    let allImages = ImageStorage.instance.images;
+    let searchIdentifiers = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                              .filter(imageTag => imageTag.tag == this.inputTag)
+                              .map(imageTag => imageTag.imageIdentifier);
+    let searchImages = allImages.filter(image => searchIdentifiers.includes(image.identifier));
+    //タグを持っていない画像も表示する
+    if (this.inputTag == '') {
+      let identifiers = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                          .map(imageTag => imageTag.imageIdentifier);
+      let noTagImages = allImages.filter(image => !identifiers.includes(image.identifier));
+      searchImages = noTagImages.concat(searchImages);
+    }
+    return searchImages;
+  }
+
   constructor(
     private changeDetector: ChangeDetectorRef,
     private panelService: PanelService
@@ -29,6 +49,18 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     EventSystem.register(this).on('SYNCHRONIZE_FILE_LIST', event => {
       if (event.isSendFromSelf) {
         this.changeDetector.markForCheck();
+      }
+    }).on('ADD_IMAGE', event => {
+      if (event.isSendFromSelf) {
+        let imageIdentifier = event.data;
+        let doubleCheckArray = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                     .filter(imageTag => imageTag.imageIdentifier == imageIdentifier)
+                     .filter(imageTag => imageTag.tag == this.inputTag);
+        if (doubleCheckArray.length) return;
+        let imageTag: ImageTag = new ImageTag();
+        imageTag.imageIdentifier = imageIdentifier;
+        imageTag.tag = this.inputTag;
+        imageTag.initialize();
       }
     });
   }
@@ -44,6 +76,15 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
 
   onSelectedFile(file: ImageFile) {
     console.log('onSelectedFile', file);
+    this.selectedFile = file;
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
+  }
+
+  deleteTag() {
+    if(!this.selectedFile) return;
+    let imageFile = ImageStorage.instance.get(this.selectedFile.identifier);
+    let imageTags = ObjectStore.instance.getObjects<ImageTag>(ImageTag)
+                     .filter(imageTag => imageTag.imageIdentifier == imageFile.identifier);
+    imageTags.forEach(imageTag => imageTag.destroy());
   }
 }

--- a/src/app/component/file-storage/file-storage.component.ts
+++ b/src/app/component/file-storage/file-storage.component.ts
@@ -80,7 +80,7 @@ export class FileStorageComponent implements OnInit, OnDestroy, AfterViewInit {
     EventSystem.call('SELECT_FILE', { fileIdentifier: file.identifier }, Network.peerId);
   }
 
-  deleteTag() {
+  moveToGarbage() {
     if(!this.selectedFile) return;
     let imageFile = ImageStorage.instance.get(this.selectedFile.identifier);
     let imageTags = ObjectStore.instance.getObjects<ImageTag>(ImageTag)

--- a/src/app/service/save-data.service.ts
+++ b/src/app/service/save-data.service.ts
@@ -45,10 +45,9 @@ export class SaveDataService {
   saveGameObject(gameObject: GameObject, fileName: string = 'xml_data') {
     let files: File[] = [];
     let xml: string = this.convertToXml(gameObject);
+    let imageFiles = this.searchImageFiles(xml)
 
     files.push(new File([xml], 'data.xml', { type: 'text/plain' }));
-
-    let imageFiles = this.searchImageFiles(xml)
     files = files.concat(imageFiles);
 
     let imageTags = ObjectStore.instance.getObjects<ImageTag>(ImageTag)


### PR DESCRIPTION
#88 の別実装です。
#92 の実装を大いに参考にしています。

### 概要
#92 と同様にタグをObjectNodeとして共有しています。
一方でImageTagListを作っていないので管理はObjectStoreのみを利用します。

基本的な流れは以下の通りです。
タグの追加
１．画像を投稿する
２．ImageStorageが画像追加を知らせるイベントを発火する
３．FileStorageComponentがイベントを受け取ってタグを生成する
一つのタグにつき一つのImageTagを生成します。
一つの画像に対して複数のタグを設定可能です。
一つの画像に対して同じタグを二つ以上設定することは出来ません。
FileStorageComponentが起動していない場合、タグは生成されません。
また、タグの変更は実装していません。
#92 との大きな違いとして、app/core/内部に手を入れてしまっていることが挙げられます。
その代わりに得られる利点として、タグの生成は画像投稿時に行われます。

画像検索
１．テキストボックスにタグを入力する
２．ImageStorageの画像とタグを比較し、一致したものを表示する
※特殊な処理として以下の二点が実装されています
・"all"と入力すると、ImageStorageの画像をそのまま表示する
・""(空文字列)を入力すると、タグが追加されていない画像を表示する
検索はFileStorageComponentとFileSelecterComponentで可能です。
検索は完全一致に限ります。

画像の疑似削除
１．FileStorageComponentに表示されている、消したい画像をクリックする
２．FileStorageComponentに表示されているに表示されているボタンを押すと、タグをすべて削除し、"garbag"というタグを生成する。
ゴミ箱に移動するイメージで作成しましたが、ゴミ箱を空にする機能やゴミ箱を元に戻す機能などはありません。
FileStorageComponentでのみ使用可能です。

タグのzip保存
１．タグ一覧と保存する画像一覧を取得する
２．保存する画像一覧に存在するタグをconvertToXmlを利用してXmlファイルに保存する
タグ一つにつき一つのファイルを保存します。
ファイル名は「画像ID@タグ.xml」です。

タグのzip読み込み
特に追加の実装はありません。
自然にタグが生成されます。

### 懸念点
・FileStorageComponentを起動している状態でzip読み込みを行うと、zip内部の全ての画像に対してFileStorageComponentに表示されているタグが生成されてしまう。
・疑似削除を行った場合も含めて、タグ一つにつき一つのファイルを生成するのでzip内部が混沌としてしまう
・cssに手を入れていないので選択した画像のハイライトが表示されず、どの画像を選択しているのかわからない

懸念事項とは少し違うかもしれませんが、この実装は #92 を大いに参考にしています。そのため、 #92 にコミットを追加する形で実装したほうがよかったかもしれません。