### PR TITLE
feat：タブを最後尾に移動

### DIFF
--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.html
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.html
@@ -16,6 +16,7 @@
       <div>
         <ng-container *ngIf="!isDeleted">
           <button (click)="save()">保存</button>
+          <button (click)="moveLast()">最後尾へ</button>
           <button class="danger" (click)="delete()" [attr.disabled]="chatTabs.length <= 1 ? '' : null">削除</button>
         </ng-container>
         <ng-container *ngIf="isDeleted">

--- a/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
+++ b/src/app/component/chat-tab-setting/chat-tab-setting.component.ts
@@ -81,4 +81,10 @@ export class ChatTabSettingComponent implements OnInit, OnDestroy {
       this.selectedTabXml = '';
     }
   }
+
+  moveLast() {
+    this.delete();
+    this.restore();
+    this.selectedTab = null;
+  }
 }


### PR DESCRIPTION
## 概要
　ユドナリウムでルームデータを読み込んだ際、たまにタブの順番が変わってしまう事象を確認しています。（1.10.3からチャットの読み込みが早くなったので、発生頻度は少なくなっている可能性はあります）
　「メインタブ」の前に「雑談」があったりすると、タブ誤爆のもとになったり、なにより気持ち悪いです。
　なので、せめてもの追加機能として、「選択したタブを最後尾に送る」機能を追加しました。


## 詳細
- タブ設定画面に「最後尾へ」ボタンを追加

- 「最後尾へ」ボタンを押すと、選択したタブがタブ一覧の最後尾に移動する。
（実行後は、チャットウィンドウの更新が必要）


## 内部仕様
「最後尾へ」ボタンで行っているのは、以下の既存コマンドです。

1. deleteコマンドでタブ削除

1. restoreコマンドで元に戻す

1. タブ選択を解除