### PR TITLE
Issues #114 マップマスクに文字を書く

### DIFF
--- a/src/app/class/game-table-mask.ts
+++ b/src/app/class/game-table-mask.ts
@@ -14,8 +14,9 @@ export class GameTableMask extends TabletopObject {
     let num = element ? <number>element.currentValue / <number>element.value : 1;
     return Number.isNaN(num) ? 1 : num;
   }
+  get text(): string { return this.getCommonValue('text', ''); }
 
-  static create(name: string, width: number, height: number, opacity: number, identifier?: string): GameTableMask {
+  static create(name: string, width: number, height: number, opacity: number, identifier?: string, text?: string): GameTableMask {
     let object: GameTableMask = null;
 
     if (identifier) {
@@ -29,6 +30,7 @@ export class GameTableMask extends TabletopObject {
     object.commonDataElement.appendChild(DataElement.create('width', width, {}, 'width_' + object.identifier));
     object.commonDataElement.appendChild(DataElement.create('height', height, {}, 'height_' + object.identifier));
     object.commonDataElement.appendChild(DataElement.create('opacity', opacity, { type: 'numberResource', currentValue: opacity }, 'opacity_' + object.identifier));
+    object.commonDataElement.appendChild(DataElement.create('text', text, {}, 'text_' + object.identifier))
     object.initialize();
 
     return object;

--- a/src/app/component/game-table-mask/game-table-mask.component.css
+++ b/src/app/component/game-table-mask/game-table-mask.component.css
@@ -46,6 +46,10 @@
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+  text-shadow:1px 1px 0 #000000, -1px -1px 0 #000000,
+              -1px 1px 0 #000000, 1px -1px 0 #000000,
+              0px 1px 0 #000000,  0-1px 0 #000000,
+              -1px 0 0 #000000, 1px 0 0 #000000;
 }
 
 .is-center {

--- a/src/app/component/game-table-mask/game-table-mask.component.css
+++ b/src/app/component/game-table-mask/game-table-mask.component.css
@@ -40,6 +40,14 @@
   height: 25px;
 }
 
+.text {
+  color: #ffffff;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
 .is-center {
   position: absolute;
   top: 0;
@@ -58,3 +66,4 @@
   height: 100%;
   width: 100%;
 }
+

--- a/src/app/component/game-table-mask/game-table-mask.component.html
+++ b/src/app/component/game-table-mask/game-table-mask.component.html
@@ -13,4 +13,5 @@
   <div *ngIf="isLock" class="lock-icon is-center">
     <i class="material-icons">lock</i>
   </div>
+  <div class="text"> {{text}} </div>
 </div>

--- a/src/app/component/game-table-mask/game-table-mask.component.ts
+++ b/src/app/component/game-table-mask/game-table-mask.component.ts
@@ -40,6 +40,7 @@ export class GameTableMaskComponent implements OnInit, OnDestroy, AfterViewInit 
   get imageFile(): ImageFile { return this.gameTableMask.imageFile; }
   get isLock(): boolean { return this.gameTableMask.isLock; }
   set isLock(isLock: boolean) { this.gameTableMask.isLock = isLock; }
+  get text(): string { return this.gameTableMask.text; }
 
   gridSize: number = 50;
 


### PR DESCRIPTION
## 概要
Issues #114 で要望として上がっていた、マップマスクへの文字埋め込みを実装しました。
ユドナリウムの基本的なUXに合わせる形で、要望から実装を変えてあります。

## 詳細
- マップマスクの詳細「common」分類に、"text"を追加
- textに記載した文字が、マップマスクの中央に書かれる
- 文字色：白、文字縁取り：黒で固定。フォントも固定。
- セーブ・ロードで文字も保存される

## 懸念点
改行の動作が、半角のみの場合と全角文字混じりの場合で異なります。
（半角：改行なし、　全角：自動で一定幅で改行）