### PR TITLE
feat: チャット画面 / チャットパレットのアイコンから画像変更画面を開く

### DIFF
--- a/src/app/component/chat-input/chat-input.component.html
+++ b/src/app/component/chat-input/chat-input.component.html
@@ -1,6 +1,6 @@
 <div class="table" [ngClass]="{ 'direct-message': isDirect }">
   <div class="table-cell imagebox">
-    <img *ngIf="0 < imageFile.url.length" class="image" [src]="imageFile.url | safe: 'resourceUrl'" />
+    <img (click)="openCharacterImageChange()" *ngIf="0 < imageFile.url.length" class="image" [src]="imageFile.url | safe: 'resourceUrl'" />
   </div>
   <div class="table-cell">
     <div>
@@ -24,7 +24,7 @@
     </div>
     <div>
       <form>
-        <textarea class="chat-input" placeholder="Enterで送信  Shift+Enterで改行" [(ngModel)]="text"
+        <textarea class="chat-input" placeholder="Enterで送信  Shift+Enterで改行 アイコンクリックで画像変更" [(ngModel)]="text"
           [ngModelOptions]="{standalone: true}" (input)="onInput()" (keydown.enter)="sendChat($event)"
           #textArea></textarea>
         <button type="submit" (click)="sendChat(null)">SEND</button>

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -237,27 +237,19 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
   openCharacterImageChange() {
     let object = ObjectStore.instance.get(this.sendFrom);
-    if(!object) {
-      console.log("this is null")
-      return;
-    }
+    if(!object) return;
 
     this.modalService.open<string>(FileSelecterComponent, { isAllowedEmpty: true }).then(value => {
-      let object = ObjectStore.instance.get(this.sendFrom);
-      
-
       if(object instanceof PeerCursor) {
-        console.log("this is peerCursor");
         if(!object.image || !value) return;
         object.imageIdentifier = value;
       }
       else if(object instanceof GameCharacter) {
-        console.log("this is character");
         if(!object.imageDataElement || !value) return;
         let element = object.imageDataElement.getFirstElementByName('imageIdentifier');
         if(!element) return;
         element.value = value;
-      } 
+      } else return;
     });
     
   }

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -11,6 +11,8 @@ import { TextViewComponent } from 'component/text-view/text-view.component';
 import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { FileSelecterComponent } from 'component/file-selecter/file-selecter.component';
+import { ModalService } from 'service/modal.service';
 
 @Component({
   selector: 'chat-input',
@@ -84,7 +86,8 @@ export class ChatInputComponent implements OnInit, OnDestroy {
     private ngZone: NgZone,
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private modalService: ModalService
   ) { }
 
   ngOnInit(): void {
@@ -229,6 +232,10 @@ export class ChatInputComponent implements OnInit, OnDestroy {
         + '===================================\n'
         + this.gameHelp;
     });
+  }
+
+  openCharacterImageChange() {
+    
   }
 
   private allowsChat(gameCharacter: GameCharacter): boolean {

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -13,6 +13,7 @@ import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
 import { FileSelecterComponent } from 'component/file-selecter/file-selecter.component';
 import { ModalService } from 'service/modal.service';
+import { PeerCursorComponent } from 'component/peer-cursor/peer-cursor.component';
 
 @Component({
   selector: 'chat-input',
@@ -236,21 +237,27 @@ export class ChatInputComponent implements OnInit, OnDestroy {
 
   openCharacterImageChange() {
     let object = ObjectStore.instance.get(this.sendFrom);
-    if(!object) return;
+    if(!object) {
+      console.log("this is null")
+      return;
+    }
 
     this.modalService.open<string>(FileSelecterComponent, { isAllowedEmpty: true }).then(value => {
-      let character = ObjectStore.instance.get<GameCharacter>(this.sendFrom);
-      let peer = ObjectStore.instance.get<PeerCursor>(this.sendFrom);
+      let object = ObjectStore.instance.get(this.sendFrom);
+      
 
-      if(character) {
-        if(!character.imageDataElement || !value) return;
-        let element = character.imageDataElement.getFirstElementByName('imageIdentifier');
+      if(object instanceof PeerCursor) {
+        console.log("this is peerCursor");
+        if(!object.image || !value) return;
+        object.imageIdentifier = value;
+      }
+      else if(object instanceof GameCharacter) {
+        console.log("this is character");
+        if(!object.imageDataElement || !value) return;
+        let element = object.imageDataElement.getFirstElementByName('imageIdentifier');
         if(!element) return;
         element.value = value;
-      } else if(peer) {
-        if(!peer.imageIdentifier || !value) return;
-        peer.imageIdentifier = value;
-      }
+      } 
     });
     
   }

--- a/src/app/component/chat-input/chat-input.component.ts
+++ b/src/app/component/chat-input/chat-input.component.ts
@@ -235,6 +235,23 @@ export class ChatInputComponent implements OnInit, OnDestroy {
   }
 
   openCharacterImageChange() {
+    let object = ObjectStore.instance.get(this.sendFrom);
+    if(!object) return;
+
+    this.modalService.open<string>(FileSelecterComponent, { isAllowedEmpty: true }).then(value => {
+      let character = ObjectStore.instance.get<GameCharacter>(this.sendFrom);
+      let peer = ObjectStore.instance.get<PeerCursor>(this.sendFrom);
+
+      if(character) {
+        if(!character.imageDataElement || !value) return;
+        let element = character.imageDataElement.getFirstElementByName('imageIdentifier');
+        if(!element) return;
+        element.value = value;
+      } else if(peer) {
+        if(!peer.imageIdentifier || !value) return;
+        peer.imageIdentifier = value;
+      }
+    });
     
   }
 


### PR DESCRIPTION
（Ver1.11.1のチャットウィンドウ周りの変更に伴い、 #89 と同じ機能を新しいプルリクエストとして上げ直しました）

## 概要
　チャットウィンドウおよびチャットパレットのアイコンをクリックすると、該当のキャラクターコマの画像変更ウィンドウが開くようにしました。変更すると、キャラクターコマの「画像変更」を押したときと同様に、コマの画像変更（と、他参加者への反映）が行われます。
　チャット中、表情差分や変身などの契機で、咄嗟にキャラクターアイコンを変更したい場合を想定しています。

## 修正点
- チャットウィンドウのアイコンをクリックすると、対応したキャラクターコマの画像選択ウィンドウがモーダルで開きます。

- 発話者の選択が「自分のニックネーム（あなた）」の場合は、自分のアイコンを変更するウィンドウが開きます。（接続情報ウィンドウの「アイコンを変更する」ボタンと同じ）

- いずれも、変更した場合は通常通り画像変更した場合と同様、ボードの上のキャラクター画像に反映され、他の人にも共有されます。

- チャット入力ボックスのデフォルト欄に、「アイコンクリックで画像変更」という一文を加えました。（機能追加だけだと、ウィンドウが開くことに気づけないため）

（以上）