### PR TITLE
インベントリにて標準のダイスボットを設定できるよう機能追加 (Issue #42) 

### DIFF
--- a/src/app/class/data-summary-setting.ts
+++ b/src/app/class/data-summary-setting.ts
@@ -22,6 +22,7 @@ export class DataSummarySetting extends GameObject implements InnerXml {
   @SyncVar() sortTag: string = 'name';
   @SyncVar() sortOrder: SortOrder = SortOrder.ASC;
   @SyncVar() dataTag: string = 'HP MP 敏捷度 生命力 精神力';
+  @SyncVar() gameType: string = "";
 
   private _dataTag: string;
   private _dataTags: string[];

--- a/src/app/component/chat-window/chat-window.component.ts
+++ b/src/app/component/chat-window/chat-window.component.ts
@@ -8,6 +8,7 @@ import { ChatTabSettingComponent } from 'component/chat-tab-setting/chat-tab-set
 import { ChatMessageService } from 'service/chat-message.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { GameObjectInventoryService} from 'service/game-object-inventory.service';
 
 @Component({
   selector: 'chat-window',
@@ -38,12 +39,14 @@ export class ChatWindowComponent implements OnInit, OnDestroy, AfterViewInit {
   constructor(
     public chatMessageService: ChatMessageService,
     private panelService: PanelService,
-    private pointerDeviceService: PointerDeviceService
+    private pointerDeviceService: PointerDeviceService,
+    private inventoryService: GameObjectInventoryService
   ) { }
 
   ngOnInit() {
     this.sendFrom = PeerCursor.myCursor.identifier;
     this._chatTabidentifier = 0 < this.chatMessageService.chatTabs.length ? this.chatMessageService.chatTabs[0].identifier : '';
+    this.gameType = this.inventoryService.gameType;
 
     EventSystem.register(this)
       .on('MESSAGE_ADDED', event => {

--- a/src/app/component/game-object-inventory/game-object-inventory.component.html
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.html
@@ -32,6 +32,11 @@
     </div>
     <div style="font-size: 12px; padding-top: 6px;">表示項目</div>
     <input style="width: 100%; box-sizing: border-box;" [(ngModel)]="dataTag" placeholder="スペース区切りでタグ名 スラッシュで改行 ex.「HP MP / メモ」" />
+    <div style="font-size: 12px; padding-top: 6px;">標準ダイスボット</div>
+    <select style="width: 12em;" (change)="onChangeGameType($event.target.value)" [(ngModel)]="gameType" [ngModelOptions]="{standalone: true}">
+      <option value="">ダイスボット指定なし</option>
+      <option *ngFor="let diceBotInfo of diceBotInfos" value="{{diceBotInfo.script}}">{{diceBotInfo.game}}</option>
+    </select>
     <div style="padding-top: 6px;">
       <button class="tab-setting small-font" (click)="toggleEdit()"><i class="material-icons small-font">settings</i>完了</button>
     </div>

--- a/src/app/component/game-object-inventory/game-object-inventory.component.ts
+++ b/src/app/component/game-object-inventory/game-object-inventory.component.ts
@@ -15,6 +15,7 @@ import { ContextMenuAction, ContextMenuService, ContextMenuSeparator } from 'ser
 import { GameObjectInventoryService } from 'service/game-object-inventory.service';
 import { PanelOption, PanelService } from 'service/panel.service';
 import { PointerDeviceService } from 'service/pointer-device.service';
+import { DiceBot } from '@udonarium/dice-bot';
 
 @Component({
   selector: 'game-object-inventory',
@@ -41,6 +42,10 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
   get sortOrderName(): string { return this.sortOrder === SortOrder.ASC ? '昇順' : '降順'; }
 
   get newLineString(): string { return this.inventoryService.newLineString; }
+
+  get diceBotInfos() { return DiceBot.diceBotInfos }
+  get gameType(): string { return this.inventoryService.gameType; }
+  set gameType(gameType: string) { this.inventoryService.gameType = gameType; }
 
   constructor(
     private changeDetector: ChangeDetectorRef,
@@ -215,5 +220,12 @@ export class GameObjectInventoryComponent implements OnInit, AfterViewInit, OnDe
 
   trackByGameObject(index: number, gameObject: GameObject) {
     return gameObject ? gameObject.identifier : index;
+  }
+
+  onChangeGameType(gameType: string) {
+    console.log('onChangeGameType ready');
+    DiceBot.getHelpMessage(this.gameType).then(help => {
+      console.log('onChangeGameType done\n' + help + gameType);
+    });
   }
 }

--- a/src/app/service/game-object-inventory.service.ts
+++ b/src/app/service/game-object-inventory.service.ts
@@ -25,6 +25,9 @@ export class GameObjectInventoryService {
   set dataTag(dataTag: string) { this.summarySetting.dataTag = dataTag; }
   get dataTags(): string[] { return this.summarySetting.dataTags; }
 
+  get gameType(): string { return this.summarySetting.gameType; }
+  set gameType(gameType: string) {this.summarySetting.gameType = gameType; }
+  
   tableInventory: ObjectInventory = new ObjectInventory(object => { return object.location.name === 'table'; });
   commonInventory: ObjectInventory = new ObjectInventory(object => { return !this.isAnyLocation(object.location.name); });
   privateInventory: ObjectInventory = new ObjectInventory(object => { return object.location.name === Network.peerId; });


### PR DESCRIPTION
(Ver1.11.1の更新に伴い、mergeが可能なようプルリクエストを作成し直しました)

## 概要
　チャット画面、および未設定のチャットパレットのダイスボットが「ダイスボット指定なし」に固定されている点が不便に感じたため、ルームの標準ダイスボットが設定できるよう機能追加を行いました。(Issue #42 の実装です)

## 仕様詳細

- インベントリの設定項目の中に「標準ダイスボット」を追加

- 設定した標準ダイスボットは、インベントリ設定と同様に、他の参加者にも共有される

- 「チャット画面」を新しく開いたときに、標準ダイスボットに設定したダイスボットが自動で選択される

- チャットパレットを開いた際に、標準ダイスボットに設定したダイスボットが自動で選択される。ただし、チャットパレットで別途ダイスボットを指定していた場合、そちらが優先される

- 設定した標準ダイスボットは、ルームデータの「summary.xml」内に保存され、ルームデータをロードすると保存された標準ダイスボットが自動で設定される

## 懸念点

- 本来、インベントリと無関係な標準ダイスボットをインベントリの設定項目のひとつとして扱っている点。（他に、いい場所が思いつきませんでした）