### PR TITLE
feat: 山札をN人分に分割する

### DIFF
--- a/src/app/component/card-stack/card-stack.component.ts
+++ b/src/app/component/card-stack/card-stack.component.ts
@@ -289,6 +289,19 @@ export class CardStackComponent implements OnInit, AfterViewInit, OnDestroy {
         }
       },
       {
+        name: '山札をN人分に分割する', action: null,
+        subActions: Array.from({ length: 9 }, (_, i) => {
+          const N = i + 2;
+          return {
+            name: N + '人分',
+            action: () => {
+              this.splitStack(N);
+              SoundEffect.play(PresetSound.cardDraw);
+            }
+          };
+        })
+      },
+      {
         name: '山札を崩す', action: () => {
           this.breakStack();
           SoundEffect.play(PresetSound.cardShuffle);


### PR DESCRIPTION
## 詳細
Fix #141 (山札を右クリックしたときに表示されるコンテキストメニューに「山札をN人分に分割する」を追加).
2〜10人分の分割に対応。