### PR TITLE
feat: カードを複数人で見れるように対応

### DIFF
--- a/src/app/class/card-stack.ts
+++ b/src/app/class/card-stack.ts
@@ -118,7 +118,7 @@ export class CardStack extends TabletopObject {
   putOnTop(card: Card): Card {
     if (!this.cardRoot) return null;
     if (!this.topCard) return this.putOnBottom(card);
-    card.owner = '';
+    card.owners = [];
     card.zindex = 0;
     let delta = Math.abs(card.rotate - this.rotate);
     if (180 < delta) delta = 360 - delta;
@@ -129,7 +129,7 @@ export class CardStack extends TabletopObject {
 
   putOnBottom(card: Card): Card {
     if (!this.cardRoot) return null;
-    card.owner = '';
+    card.owners = [];
     card.zindex = 0;
     let delta = Math.abs(card.rotate - this.rotate);
     if (180 < delta) delta = 360 - delta;

--- a/src/app/class/card.ts
+++ b/src/app/class/card.ts
@@ -15,7 +15,7 @@ export enum CardState {
 export class Card extends TabletopObject {
   @SyncVar() state: CardState = CardState.FRONT;
   @SyncVar() rotate: number = 0;
-  @SyncVar() owner: string = '';
+  @SyncVar() owners: Array<string> = [];
   @SyncVar() zindex: number = 0;
 
   get isVisibleOnTable(): boolean { return this.location.name === 'table' && (!this.parentIsAssigned || this.parentIsDestroyed); }
@@ -29,23 +29,25 @@ export class Card extends TabletopObject {
   get imageFile(): ImageFile { return this.isVisible ? this.frontImage : this.backImage; }
 
   get ownerName(): string {
-    let object = PeerCursor.findByUserId(this.owner);
-    return object ? object.name : '';
+    return this.owners.map(owner => PeerCursor.findByUserId(owner))
+      .filter(peerCursor => peerCursor)
+      .map(peerCursor => peerCursor.name)
+      .join(', ');
   }
 
-  get hasOwner(): boolean { return 0 < this.owner.length; }
-  get isHand(): boolean { return Network.peerContext.userId === this.owner; }
+  get hasOwner(): boolean { return 0 < this.owners.length; }
+  get isHand(): boolean { return this.owners.includes(Network.peerContext.userId); }
   get isFront(): boolean { return this.state === CardState.FRONT; }
   get isVisible(): boolean { return this.isHand || this.isFront; }
 
   faceUp() {
     this.state = CardState.FRONT;
-    this.owner = '';
+    this.owners = [];
   }
 
   faceDown() {
     this.state = CardState.BACK;
-    this.owner = '';
+    this.owners = [];
   }
 
   toTopmost() {

--- a/src/app/service/context-menu.service.ts
+++ b/src/app/service/context-menu.service.ts
@@ -61,7 +61,7 @@ export class ContextMenuService {
 
     childPanelService.panelComponentRef = panelComponentRef;
     if (actions) {
-      childPanelService.actions = actions;
+      childPanelService.actions = actions.filter(act => act.enabled === undefined || act.enabled);
     }
     if (position) {
       childPanelService.position.x = position.x;


### PR DESCRIPTION
- カードを特定のユーザのみが見ている、かつ、
  それ以外のユーザがそのカードを右クリックした場合のコンテキストメニューに「自分も見る」を追加
- 特定のユーザのみがカードを見ている、かつ、
  その特定のユーザがカードを右クリックした場合のコンテキストメニューの「裏にする」を「見るのをやめる」に変更

https://github.com/TK11235/udonarium/issues/62#issuecomment-543064939 の以下の要望もこちらのPRで解決されます。

> GMがプレイヤーが伏せてセットしたカードを確認するときに「自分だけが見る」としたとき。セットしたPLからも見えなくなります。
> 改めてPLが「自分だけが見る」とすればいいのですが。GMは他に影響を与えないようにカードを確認したいときがあります。